### PR TITLE
Switch back to an older versions of things

### DIFF
--- a/datahub/config.yaml
+++ b/datahub/config.yaml
@@ -1,4 +1,4 @@
-version: "v0.5.0-393cbb3"
+version: "v0.5.0-58e8ef6"
 
 
 hub:


### PR DESCRIPTION
This moves us back to an older version of kubespawner,
jupyterhub 0.8b1 and CHP. This is a much more conservative
change than using traefik, so let's do this.