### PR TITLE
Disable sqlite as provider of ipython history

### DIFF
--- a/user-image/Dockerfile
+++ b/user-image/Dockerfile
@@ -23,6 +23,8 @@ RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && \
 ENV LC_ALL en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US.UTF-8
+# Set this to be on container storage, rather than under $HOME
+ENV IPYTHONDIR ${APP_DIR}/venv/etc/ipython
 
 RUN adduser --disabled-password --gecos "Default Jupyter user" jovyan
 
@@ -66,10 +68,6 @@ RUN pip install git+https://github.com/data-8/nbresuse.git@2f9144f && \
 RUN pip install git+https://github.com/data-8/gitautosync@b32a087 && \
 	jupyter serverextension enable  --sys-prefix --py nbgitautosync
 
-# disable history.sqlite
-ENV IPYTHONDIR ${APP_DIR}/venv/etc/ipython
-RUN mkdir -p ${IPYTHONDIR}/profile_default && \
-	echo "c.HistoryManager.enabled = False" > \
-	${IPYTHONDIR}/profile_default/ipython_config.py
+ADD ipython_config.py ${IPYTHONDIR}/ipython_config.py
 
 EXPOSE 8888

--- a/user-image/Dockerfile
+++ b/user-image/Dockerfile
@@ -66,4 +66,10 @@ RUN pip install git+https://github.com/data-8/nbresuse.git@2f9144f && \
 RUN pip install git+https://github.com/data-8/gitautosync@b32a087 && \
 	jupyter serverextension enable  --sys-prefix --py nbgitautosync
 
+# disable history.sqlite
+ENV IPYTHONDIR ${APP_DIR}/venv/etc/ipython
+RUN mkdir -p ${IPYTHONDIR}/profile_default && \
+	echo "c.HistoryManager.enabled = False" > \
+	${IPYTHONDIR}/profile_default/ipython_config.py
+
 EXPOSE 8888

--- a/user-image/ipython_config.py
+++ b/user-image/ipython_config.py
@@ -1,0 +1,3 @@
+# Disable history manager, we don't really use it
+# and by default it puts an sqlite file on NFS, which is not something we wanna do
+c.Historymanager.enabled = False


### PR DESCRIPTION
We don't actually need it, and it puts an sqlite file on NFS which is meh.