### PR TITLE
Updating scipy, adding nano, vim, and gfortran for phys151.

### DIFF
--- a/user-image/Dockerfile
+++ b/user-image/Dockerfile
@@ -14,7 +14,11 @@ RUN apt-get update && \
             wget \
             npm \
             nodejs-legacy \
-            locales && \
+            locales \
+            nano \
+            vim \
+            # for phys 151
+            gfortran && \
     apt-get purge && apt-get clean
 
 RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && \

--- a/user-image/requirements.txt
+++ b/user-image/requirements.txt
@@ -4,7 +4,7 @@ datascience==0.10.0
 matplotlib==2.0.0
 numpy==1.12.1
 pandas==0.19.2
-scipy==0.19.0
+scipy==0.19.1
 statsmodels==0.8.0
 okpy==1.12.5
 #


### PR DESCRIPTION
Updating from 0.19.0 to 0.19.1. This is to deal with memory leaks in `quad()`, described [here](
https://github.com/scipy/scipy/issues/7214). 
Also added vim, nano, and gfortran. 
@rainwoodman