### PR TITLE
First homework requires pandoc

### DIFF
--- a/user-image/Dockerfile
+++ b/user-image/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get update && \
             nano \
             vim \
             # for nbconvert
+            pandoc \
             texlive-xetex \
             texlive-fonts-recommended \
             texlive-generic-recommended \


### PR DESCRIPTION
Simple notebooks work fine as-is. Testing the first homework showed that pandoc is also required.