### PR TITLE
adding folium

### DIFF
--- a/user-image/requirements.txt
+++ b/user-image/requirements.txt
@@ -36,6 +36,7 @@ seaborn==0.8.0
 bokeh==0.12.6
 decorator==4.1.2
 networkx==1.11
+folium=0.5.0
 #
 # phys 151;
 emcee==2.2.1

--- a/user-image/requirements.txt
+++ b/user-image/requirements.txt
@@ -36,7 +36,7 @@ seaborn==0.8.0
 bokeh==0.12.6
 decorator==4.1.2
 networkx==1.11
-folium=0.5.0
+folium==0.5.0
 #
 # phys 151;
 emcee==2.2.1


### PR DESCRIPTION
Adding `folium` to requirements.txt for mapping capabilities. `datascience` uses an older version of folium, but in order to run straight `folium`, it needs the update to version 0.5.0.