### PR TITLE
Revert "adding folium", breaks datascience.maps

### DIFF
--- a/user-image/requirements.txt
+++ b/user-image/requirements.txt
@@ -36,7 +36,6 @@ seaborn==0.8.0
 bokeh==0.12.6
 decorator==4.1.2
 networkx==1.11
-folium==0.5.0
 #
 # phys 151;
 emcee==2.2.1


### PR DESCRIPTION
Reverts berkeley-dsep-infra/datahub#115

methods used in the data8 textbook were renamed in the newer `folium` version.

@vinitra could you look into maybe updating the `folium` version in the `datascience` dependencies?