### PR TITLE
Add installation of nistats python package

### DIFF
--- a/user-image/connectors/neuro.bash
+++ b/user-image/connectors/neuro.bash
@@ -15,3 +15,6 @@ git checkout b4dd6d860d7c27a846a5445b0df2824429084b44
 python setup.py install
 cd .. && rm -rf pycortex
 rm -rf ~/.config/pycortex
+
+# Install the package nistats (currently not on pypi yet)
+(cd ~ && git clone https://github.com/nistats/nistats.git && cd nistats && python setup.py install && cd ~ && rm nistats -rf)


### PR DESCRIPTION
It would be great to have `nistats` available for the next cogneuro connector classes.

nistats is currently not available on pypi.
Let me know if this is the right place to install it.
For reproducibility purposes we could check out current last master commit `5a3a3ed2cbbb088e558838ea7f2a3b9e7735050a`