### PR TITLE
Update JupyterHub version

### DIFF
--- a/datahub/config.yaml
+++ b/datahub/config.yaml
@@ -1,4 +1,4 @@
-version: "v0.6.0-a3007b2"
+version: "v0.6.0-dcb92ba"
 
 hub:
   db:


### PR DESCRIPTION
Should bring in version of prepuller with
https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/458 fixed.