### PR TITLE
Bump to latest z2jh

### DIFF
--- a/datahub/config.yaml
+++ b/datahub/config.yaml
@@ -1,4 +1,4 @@
-version: "v0.6.0-7dcc6aa"
+version: "v0.7.0-4b122ad"
 
 hub:
   db:


### PR DESCRIPTION
Gets us the new autoscaler from https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/502