### PR TITLE
Add apt-get imagemagick to dockerfile

### DIFF
--- a/user-image/Dockerfile
+++ b/user-image/Dockerfile
@@ -35,7 +35,7 @@ RUN apt-get update && \
             # for phys 151
             gfortran \
 	    # for cogneuro
-	    dirmngr
+	    dirmngr \
 	    imagemagick
 
 # for cogneuro connector, adding NeuroDebian repo

--- a/user-image/Dockerfile
+++ b/user-image/Dockerfile
@@ -36,6 +36,7 @@ RUN apt-get update && \
             gfortran \
 	    # for cogneuro
 	    dirmngr
+	    imagemagick
 
 # for cogneuro connector, adding NeuroDebian repo
 RUN wget http://neuro.debian.net/lists/zesty.us-ca.full  -O /etc/apt/sources.list.d/neurodebian.sources.list


### PR DESCRIPTION
In order for pycortex to be able to render SVG-based regions of interest on flatmaps, it turns out that we need the imagemagick `convert` binary installed. I added a line to install all of imagemagick. 

Is there any chance for this to be staged + added to production by tomorrow? (That is the date of our last cogneuro connector class and it would be amazing if we could have this functionality for it).

Thanks!
Michael