### PR TITLE
Downgrade nbconvert

### DIFF
--- a/deployments/datahub/image/requirements.txt
+++ b/deployments/datahub/image/requirements.txt
@@ -1,7 +1,7 @@
 #
 # data8; foundation
 tornado==4.5.3
-notebook==5.4.1
+notebook==5.6.0
 datascience==0.10.4
 matplotlib==2.0.0
 numpy==1.14.5
@@ -88,6 +88,7 @@ opencv-python==3.3.0.10
 prob140==0.3.5.1
 gsExport==0.18.8.1
 sympy==1.1.1
+nbconvert<5
 #
 # stat 159/259; fall 18
 git+git://github.com/statlab/permute.git@e2b13ed

--- a/deployments/datahub/image/requirements.txt
+++ b/deployments/datahub/image/requirements.txt
@@ -1,7 +1,7 @@
 #
 # data8; foundation
 tornado==4.5.3
-notebook==5.6.0
+notebook==5.4.1
 datascience==0.10.4
 matplotlib==2.0.0
 numpy==1.14.5
@@ -92,3 +92,4 @@ sympy==1.1.1
 # stat 159/259; fall 18
 git+git://github.com/statlab/permute.git@e2b13ed
 git+git://github.com/statlab/cryptorandom.git@0721472
+


### PR DESCRIPTION
nbconvert>=5 ignores latex compilation errors and just compiles the pdf up until the error. This is a problem for students who don't realize that their assignment output is incomplete.

Let me know when it gets added to staging for testing!