### PR TITLE
Upgrade datascience module to 0.10.6

### DIFF
--- a/deployments/datahub/image/requirements.txt
+++ b/deployments/datahub/image/requirements.txt
@@ -2,7 +2,7 @@
 # data8; foundation
 tornado==4.5.3
 notebook==5.6.0
-datascience==0.10.4
+datascience==0.10.6
 matplotlib==2.0.0
 numpy==1.14.5
 pandas==0.19.2


### PR DESCRIPTION
Upgrading datascience to 0.10.6 for visualization improvements. See https://github.com/data-8/datascience/pull/325 for more details.