### PR TITLE
Manually namespace the hostPath.

### DIFF
--- a/deployments/prob140/config/prod.yaml
+++ b/deployments/prob140/config/prod.yaml
@@ -1,6 +1,6 @@
 nfsMounter:
   mounts:
-    - nfsserver1:/export/pool0/homes/_prob140=/data/homes/prod
+    - nfsserver1:/export/pool0/homes/_prob140=/data/homes/prob140-prod
 
 jupyterhub:
   proxy:

--- a/deployments/prob140/config/staging.yaml
+++ b/deployments/prob140/config/staging.yaml
@@ -1,6 +1,6 @@
 nfsMounter:
   mounts:
-    - nfsserver1:/export/pool0/homes/_prob140=/data/homes/staging
+    - nfsserver1:/export/pool0/homes/_prob140=/data/homes/prob140-staging
 
 jupyterhub:
   proxy:


### PR DESCRIPTION
Otherwise our namespace's nfs share will be mounted on the same host
path. I don't think we need prod/staging distinction here but I'm just being
consistent.