### PR TITLE
data.table image 

### DIFF
--- a/deployments/datahub/image/Dockerfile
+++ b/deployments/datahub/image/Dockerfile
@@ -74,7 +74,7 @@ RUN apt-get -qq install --yes \
             r-cran-crayon \
             r-cran-crosstalk \
             r-cran-curl \
-            r-data.table \
+            r-cran-data.table \
             r-cran-dbi \
             r-cran-devtools \
             r-cran-digest \

--- a/deployments/datahub/image/Dockerfile
+++ b/deployments/datahub/image/Dockerfile
@@ -74,6 +74,7 @@ RUN apt-get -qq install --yes \
             r-cran-crayon \
             r-cran-crosstalk \
             r-cran-curl \
+            r-data.table \
             r-cran-dbi \
             r-cran-devtools \
             r-cran-digest \


### PR DESCRIPTION
Including a request to build the `data.table` [library](https://github.com/Rdatatable/data.table/wiki) for R. The build is listed in the ubuntu bionic [package repository](https://packages.ubuntu.com/bionic/gnu-r/r-cran-data.table). 