### PR TITLE
Specify static IPs for all running hubs

### DIFF
--- a/deployments/datahub/config/prod.yaml
+++ b/deployments/datahub/config/prod.yaml
@@ -4,6 +4,8 @@ nfsMounter:
 
 jupyterhub:
   proxy:
+    service:
+      loadBalancerIP: 35.232.190.188
     https:
       hosts:
         - datahub.berkeley.edu

--- a/deployments/datahub/config/staging.yaml
+++ b/deployments/datahub/config/staging.yaml
@@ -4,6 +4,8 @@ nfsMounter:
 
 jupyterhub:
   proxy:
+    service:
+      loadBalancerIP: 104.197.27.164
     https:
       hosts:
         - staging.datahub.berkeley.edu

--- a/deployments/prob140/config/prod.yaml
+++ b/deployments/prob140/config/prod.yaml
@@ -4,6 +4,8 @@ nfsMounter:
 
 jupyterhub:
   proxy:
+    service:
+      loadBalancerIP: 35.184.101.216
     https:
       hosts:
         - prob140.datahub.berkeley.edu

--- a/deployments/prob140/config/staging.yaml
+++ b/deployments/prob140/config/staging.yaml
@@ -4,6 +4,8 @@ nfsMounter:
 
 jupyterhub:
   proxy:
+    service:
+      loadBalancerIP: 35.226.250.22
     https:
       hosts:
         - prob140-staging.datahub.berkeley.edu


### PR DESCRIPTION
This makes switching back and forth between clusters
easier.