### PR TITLE
Reorder serverextension installs

### DIFF
--- a/deployments/datahub/image/Dockerfile
+++ b/deployments/datahub/image/Dockerfile
@@ -201,11 +201,11 @@ RUN /usr/local/sbin/connector-cp255.bash
 # install gmaps notebook extension
 RUN jupyter nbextension enable --py --sys-prefix gmaps
 
-# Install nbserverproxy
-RUN jupyter serverextension enable  --sys-prefix --py nbserverproxy
-
 # Install nbrsessionproxy
 RUN jupyter serverextension enable  --sys-prefix --py nbrsessionproxy
+
+# Install nbserverproxy
+RUN jupyter serverextension enable  --sys-prefix --py nbserverproxy
 
 # Install nbzip
 RUN jupyter serverextension enable  --sys-prefix --py nbzip && \


### PR DESCRIPTION
Mostly to rejig staging builds, since last build
ended up `couldn't parse image reference "gcr.io/ucb-datahub-2018/primary-user-image:5.050569e+06": invalid reference format`