### PR TITLE
Adding commands to postBuild to install/enable gofer nbextension

### DIFF
--- a/deployments/data8x/image/postBuild
+++ b/deployments/data8x/image/postBuild
@@ -4,3 +4,7 @@ set -euo pipefail
 # Create ipython config directory if it doesn't exist
 mkdir -p ${CONDA_DIR}/etc/ipython
 cp ipython_config.py ${CONDA_DIR}/etc/ipython/ipython_config.py
+
+# install and enable gofer-grader notebook extension
+jupyter nbextension install --symlink --sys-prefix ${CONDA_DIR}/Gofer-Grader/submit_extension
+jupyter nbextension enable --sys-prefix ${CONDA_DIR}/Gofer-Grader/submit_extension/submit_extension


### PR DESCRIPTION
TODO: Changes will need to be made to the nbextension to submit to
the correct address since the gofer service will not be managed by
the hub for data8x.

Note: the circle ci error is “No PR from branch gofer_nbextension in upstream repo found”, so perhaps this will re-trigger tests with the PR?