### PR TITLE
Use patched nbconvert.

### DIFF
--- a/deployments/prob140/image/requirements.txt
+++ b/deployments/prob140/image/requirements.txt
@@ -18,3 +18,6 @@ nbresuse==0.3.0
 prob140==0.4.1.2
 gsExport==0.19.1.1
 sympy==1.1.1
+#
+# nbconvert 5.4.0 with pdf export patch
+git+https://github.com/ryanlovett/nbconvert.git@16fe302


### PR DESCRIPTION
If latex produces an error but also creates a partial PDF, nbconvert will display the latex error rather than portray success.