### PR TITLE
Bypass `bibtex` with `true`.

### DIFF
--- a/deployments/prob140/image/Dockerfile
+++ b/deployments/prob140/image/Dockerfile
@@ -58,5 +58,6 @@ RUN jupyter serverextension enable  --sys-prefix --py nbzip && \
     jupyter nbextension     enable  --sys-prefix --py nbzip
 
 ADD ipython_config.py ${IPYTHONDIR}/ipython_config.py
+ADD jupyter_nbconvert_config.py ${APP_DIR}/venv/etc/jupyter/
 
 EXPOSE 8888

--- a/deployments/prob140/image/jupyter_nbconvert_config.py
+++ b/deployments/prob140/image/jupyter_nbconvert_config.py
@@ -1,0 +1,1 @@
+c.PDFExporter.bib_command = ['true']


### PR DESCRIPTION
Avoid harmless bibtex errors.