### PR TITLE
Bump hubploy version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,9 +23,6 @@ jobs:
             python3 -m venv venv
             source venv/bin/activate
             pip install --upgrade -r requirements.txt
-            # Install repo2docker explicitly since we want a higher version than the released
-            # Can't put this in requirements.txt since pip doesn't seem to realize this is a newer version
-            pip install git+https://github.com/yuvipanda/repo2docker@julia-requirements-no-verseioneer
             echo 'export PATH="${HOME}/repo/venv/bin:$PATH"' >> ${BASH_ENV}
       - setup_remote_docker
       - save_cache:
@@ -88,10 +85,6 @@ jobs:
             python3 -m venv venv
             source venv/bin/activate
             pip install --upgrade -r requirements.txt
-
-            # Install repo2docker explicitly since we want a higher version than the released
-            # Can't put this in requirements.txt since pip doesn't seem to realize this is a newer version
-            pip install git+https://github.com/yuvipanda/repo2docker@julia-requirements-no-verseioneer
 
             curl -sSL https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-226.0.0-linux-x86_64.tar.gz | tar -C venv/ -xzf -
             # Be careful with quote ordering here. ${PATH} must not be expanded

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-git+https://github.com/yuvipanda/hubploy.git@a669af1
+git+https://github.com/yuvipanda/hubploy.git@f3e26f1409d94320d1cc7690daacc23a6a465c06
 pygithub


### PR DESCRIPTION
repo2docker 0.8 has been released, and we do not
need to manually install it now.