### PR TITLE
Move docker-py upgrade out of requirements.txt

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,6 +86,9 @@ jobs:
             source venv/bin/activate
             pip install --upgrade -r requirements.txt
 
+            # Can be removed once https://github.com/docker/docker-py/issues/2225 is merged and released
+            pip install --upgrade git+https://github.com/docker/docker-py.git@b6f6e7270ef1acfe7398b99b575d22d0d37ae8bf
+
             curl -sSL https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-226.0.0-linux-x86_64.tar.gz | tar -C venv/ -xzf -
             # Be careful with quote ordering here. ${PATH} must not be expanded
             # Don't use ~ here - bash can interpret PATHs containing ~, but most other things can't.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,2 @@
 git+https://github.com/yuvipanda/hubploy.git@8b37dbb4d255c2f225894dd2ddef9cbc188e9d8b
-# Can be removed once https://github.com/docker/docker-py/issues/2225 is merged and released
-git+https://github.com/docker/docker-py.git@b6f6e7270ef1acfe7398b99b575d22d0d37ae8bf
 pygithub


### PR DESCRIPTION
I *think* this isn't being actually respected, since
both repo2docker and hubploy already depend on it.

Follow up https://github.com/berkeley-dsep-infra/datahub/pull/587