### PR TITLE
Revert previous commit.

### DIFF
--- a/deployments/datahub/image/Dockerfile
+++ b/deployments/datahub/image/Dockerfile
@@ -154,7 +154,6 @@ RUN curl --silent --location --fail ${RSTUDIO_URL} > /tmp/rstudio.deb && \
     echo "${RSTUDIO_CHECKSUM} /tmp/rstudio.deb" | md5sum -c - && \
     dpkg -i /tmp/rstudio.deb && \
     rm /tmp/rstudio.deb
-COPY rserver.conf /etc/rstudio/rserver.conf
 
 ENV PATH ${APP_DIR}/venv/bin:$PATH:/usr/lib/rstudio-server/bin
 

--- a/deployments/datahub/image/rserver.conf
+++ b/deployments/datahub/image/rserver.conf
@@ -1,3 +1,0 @@
-# Server Configuration File
-
-server-app-armor-enabled=0


### PR DESCRIPTION
rserver runs without the apparmor override but the proxying is broken.