### PR TITLE
Use external static IP instead of DNS name for grader

### DIFF
--- a/deployments/data8x/config/common.yaml
+++ b/deployments/data8x/config/common.yaml
@@ -11,7 +11,7 @@ jupyterhub:
   hub:
     services:
       gofer_nb:
-        url: http://grader:10101
+        url: http://35.239.20.122:10101
   auth:
     type: lti
     admin:


### PR DESCRIPTION
For some reason, the hub pod can not resolve the grader DNS
name anymore. We make the external IP a static IP, and use that
instead.