### PR TITLE
Install execute_time Jupyter extension

### DIFF
--- a/deployments/datahub/image/d8extension.bash
+++ b/deployments/datahub/image/d8extension.bash
@@ -7,6 +7,11 @@ cd nbextension-scratchpad/
 git checkout e92fa23
 cd ..
 jupyter nbextension install --sys-prefix nbextension-scratchpad
-jupyter nbextension enable  --sys-prefix nbextension-scratchpad/main
+jupyter nbextension enable --sys-prefix nbextension-scratchpad/main
 cd .. 
+
+pip install jupyter_contrib_nbextensions
+jupyter contrib nbextension install --sys-prefix
+jupyter nbextension enable execute_time/ExecuteTime
+
 rm -rf /tmp/nbextension-scratchpad


### PR DESCRIPTION
Installs the `execute_time` Jupyter notebook extension to get cell execution time data for assignments.

Extension:
https://github.com/ipython-contrib/jupyter_contrib_nbextensions/tree/master/src/jupyter_contrib_nbextensions/nbextensions/execute_time