### PR TITLE
Setup hadoop & spark under $CONDA_DIR

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,8 @@ jobs:
             python3 -m venv venv
             source venv/bin/activate
             pip install --upgrade -r requirements.txt
+            # Install latest repo2docker to https://github.com/jupyter/repo2docker/pull/657
+            pip install --upgrade git+https://github.com/jupyter/repo2docker@e976627c1e238cf654ad178456b1bf81db7aac36
             echo 'export PATH="${HOME}/repo/venv/bin:$PATH"' >> ${BASH_ENV}
       - setup_remote_docker
       - save_cache:
@@ -90,6 +92,8 @@ jobs:
             python3 -m venv venv
             source venv/bin/activate
             pip install --upgrade -r requirements.txt
+            # Install latest repo2docker to https://github.com/jupyter/repo2docker/pull/657
+            pip install --upgrade git+https://github.com/jupyter/repo2docker@e976627c1e238cf654ad178456b1bf81db7aac36
 
             # Can be removed once https://github.com/docker/docker-py/issues/2225 is merged and released
             pip install --upgrade git+https://github.com/docker/docker-py.git@b6f6e7270ef1acfe7398b99b575d22d0d37ae8bf

--- a/deployments/w261/image/postBuild
+++ b/deployments/w261/image/postBuild
@@ -14,23 +14,25 @@ SPARK_HOME=${CONDA_DIR}/spark
 SPARK_VERSION=2.4.2
 
 mkdir -p ${SPARK_HOME}
-cd ${SPARK_HOME}
 wget -q https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-without-hadoop.tgz -O - | \
-    tar -xz --strip 1
+    tar -xz --strip 1 -C ${SPARK_HOME}
 
 echo "Installing Spark into Python"
-cd ${SPARK_HOME}/python
 # must cd into ${SPARK_HOME}/python before running setup.py. Sigh.
+pushd .
+cd ${SPARK_HOME}/python
 python setup.py install
+popd
 
 echo "Downloading Guava and GCS connector"
-cd ${SPARK_HOME}/jars
 echo "Downloading Guava"
-GUAVA_VERSION=23.0
-wget -q http://central.maven.org/maven2/com/google/guava/guava/${GUAVA_VERSION}/guava-${GUAVA_VERSION}.jar
+GUAVA_VERSION=23.0 
+wget -q http://central.maven.org/maven2/com/google/guava/guava/${GUAVA_VERSION}/guava-${GUAVA_VERSION}.jar \
+    -o ${SPARK_HOME}/jars
 echo "Download GCS connector"
 # FIXME: Put a version here?
-wget -q https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-latest-hadoop2.jar
+wget -q https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-latest-hadoop2.jar \
+    -o ${SPARK_HOME}/jars
 
 echo "Installing Hadoop"
 # install hdfs
@@ -38,9 +40,8 @@ HADOOP_HOME=${CONDA_DIR}/hadoop
 HADOOP_VERSION=2.7.7
 
 mkdir -p ${HADOOP_HOME}
-cd ${HADOOP_HOME}
 wget -q http://archive.apache.org/dist/hadoop/core/hadoop-${HADOOP_VERSION}/hadoop-${HADOOP_VERSION}.tar.gz -O - | \
-    tar -xz --strip 1
+    tar -xz --strip 1 -C ${HADOOP_HOME}
 
 # Add GS as a filesystem to HDFS
 cp ${REPO_DIR}/core-site.xml ${HADOOP_HOME}/etc/hadoop/core-site.xml

--- a/deployments/w261/image/postBuild
+++ b/deployments/w261/image/postBuild
@@ -42,7 +42,7 @@ wget -q http://archive.apache.org/dist/hadoop/core/hadoop-${HADOOP_VERSION}/hado
     tar -xz --strip 1
 
 # Add GS as a filesystem to HDFS
-cp core-site.xml ${HADOOP_HOME}/etc/hadoop/core-site.xml
+cp ${REPO_DIR}/core-site.xml ${HADOOP_HOME}/etc/hadoop/core-site.xml
 
 # Add HDFS configs to Spark
-cp spark-env.sh ${SPARK_HOME}/conf/spark-env.sh
+cp ${REPO_DIR}/spark-env.sh ${SPARK_HOME}/conf/spark-env.sh

--- a/deployments/w261/image/postBuild
+++ b/deployments/w261/image/postBuild
@@ -20,6 +20,7 @@ wget -q https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPA
 
 echo "Installing Spark into Python"
 cd ${SPARK_HOME}/python
+# must cd into ${SPARK_HOME}/python before running setup.py. Sigh.
 python setup.py install
 
 echo "Downloading Guava and GCS connector"

--- a/deployments/w261/image/postBuild
+++ b/deployments/w261/image/postBuild
@@ -29,7 +29,7 @@ GUAVA_VERSION=23.0
 wget -q http://central.maven.org/maven2/com/google/guava/guava/${GUAVA_VERSION}/guava-${GUAVA_VERSION}.jar
 echo "Download GCS connector"
 # FIXME: Put a version here?
-curl -q https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-latest-hadoop2.jar
+wget -q https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-latest-hadoop2.jar
 
 echo "Installing Hadoop"
 # install hdfs

--- a/deployments/w261/image/postBuild
+++ b/deployments/w261/image/postBuild
@@ -28,11 +28,11 @@ echo "Downloading Guava and GCS connector"
 echo "Downloading Guava"
 GUAVA_VERSION=23.0 
 wget -q http://central.maven.org/maven2/com/google/guava/guava/${GUAVA_VERSION}/guava-${GUAVA_VERSION}.jar \
-    -o ${SPARK_HOME}/jars
+    -P ${SPARK_HOME}/jars
 echo "Download GCS connector"
 # FIXME: Put a version here?
 wget -q https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-latest-hadoop2.jar \
-    -o ${SPARK_HOME}/jars
+    -P ${SPARK_HOME}/jars
 
 echo "Installing Hadoop"
 # install hdfs

--- a/deployments/w261/image/postBuild
+++ b/deployments/w261/image/postBuild
@@ -5,60 +5,44 @@ set -euo pipefail
 mkdir -p ${CONDA_DIR}/etc/ipython
 cp ipython_config.py ${CONDA_DIR}/etc/ipython/ipython_config.py
 
-
 # Allow users to stop / start servers from JupyterLab
 jupyter labextension install @jupyterlab/hub-extension
 
 # Download Spark
-SPARK_HOME=${HOME}/spark
+echo "Download & Extract spark without Hadoop"
+SPARK_HOME=${CONDA_DIR}/spark
 SPARK_VERSION=2.4.2
-wget -q https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-without-hadoop.tgz -O spark.tgz
-tar -xzf spark.tgz
-rm spark.tgz
-mv spark-${SPARK_VERSION}-bin-without-hadoop/ ${SPARK_HOME}-${SPARK_VERSION}
-ln -s ${SPARK_HOME}-${SPARK_VERSION} ${SPARK_HOME}
+
+mkdir -p ${SPARK_HOME}
+cd ${SPARK_HOME}
+wget -q https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-without-hadoop.tgz -O - | \
+    tar -xz --strip 1
 
 echo "Installing Spark into Python"
-# Install Spark into Python
 cd ${SPARK_HOME}/python
 python setup.py install
 
 echo "Downloading Guava and GCS connector"
-# install Spark GCS connector
 cd ${SPARK_HOME}/jars
+echo "Downloading Guava"
 GUAVA_VERSION=23.0
-echo "Download Guava"
 wget -q http://central.maven.org/maven2/com/google/guava/guava/${GUAVA_VERSION}/guava-${GUAVA_VERSION}.jar
 echo "Download GCS connector"
-wget -q https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-latest-hadoop2.jar
+# FIXME: Put a version here?
+curl -q https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-latest-hadoop2.jar
 
 echo "Installing Hadoop"
 # install hdfs
-HADOOP_HOME=${HOME}/hadoop
+HADOOP_HOME=${CONDA_DIR}/hadoop
 HADOOP_VERSION=2.7.7
-echo "cd to HOME"
-cd ${HOME}
-wget -q http://archive.apache.org/dist/hadoop/core/hadoop-${HADOOP_VERSION}/hadoop-${HADOOP_VERSION}.tar.gz
-tar -xzf hadoop-${HADOOP_VERSION}.tar.gz
-ln -s ${HADOOP_HOME}-${HADOOP_VERSION} ${HADOOP_HOME}
 
-# Create a bunch of varialbes for testing in Hadoop and setting up GCP/GCS configs
-export JAVA_HOME=$(readlink -f /usr/bin/java | sed "s:bin/java::")
-export PATH=${HADOOP_HOME}/bin/:$PATH
-HADOOP_CLASSPATH="$(hadoop classpath):${SPARK_HOME}/jars/gcs-connector-latest-hadoop2.jar"
-echo 'export JAVA_HOME=$(readlink -f /usr/bin/java | sed "s:bin/java::")' >> ~/.bashrc
-echo 'export PATH=${HADOOP_HOME}/bin/:$PATH' >> ~/.bashrc
-echo "export HADOOP_CLASSPATH=${HADOOP_CLASSPATH}" >> ~/.bashrc
-echo "export GOOGLE_APPLICATION_CREDENTIALS=${HOME}/gcs-key.json" >> ~/.bashrc
-echo "export GS_PROJECT_ID=ucb-datahub-2018" >> ~/.bashrc
-echo "export SPARK_DIST_CLASSPATH=${HADOOP_CLASSPATH}" >> ~/.bashrc
+mkdir -p ${HADOOP_HOME}
+cd ${HADOOP_HOME}
+wget -q http://archive.apache.org/dist/hadoop/core/hadoop-${HADOOP_VERSION}/hadoop-${HADOOP_VERSION}.tar.gz -O - | \
+    tar -xz --strip 1
 
 # Add GS as a filesystem to HDFS
 cp core-site.xml ${HADOOP_HOME}/etc/hadoop/core-site.xml
 
 # Add HDFS configs to Spark
 cp spark-env.sh ${SPARK_HOME}/conf/spark-env.sh
-
-# cating the secret is bad, also breaks
-# How to fix?
-# workaround is to copy manually for now

--- a/deployments/w261/image/start
+++ b/deployments/w261/image/start
@@ -12,6 +12,6 @@ export HADOOP_CLASSPATH="$(hadoop classpath):${SPARK_HOME}/jars/gcs-connector-la
 
 export GOOGLE_APPLICATION_CREDENTIALS=${HOME}/gcs-key.json
 export GS_PROJECT_ID=ucb-datahub-2018
-export SPARK_DIST_CLASSPATH=${HADOOP_CLASSPATH}"
+export SPARK_DIST_CLASSPATH=${HADOOP_CLASSPATH}
 
 exec "$@"

--- a/deployments/w261/image/start
+++ b/deployments/w261/image/start
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -euo pipefail
+
+export HADOOP_HOME=${CONDA_DIR}/hadoop
+export SPARK_HOME=${CONDA_DIR}/spark
+
+# Create a bunch of varialbes for testing in Hadoop and setting up GCP/GCS configs
+export JAVA_HOME=$(readlink -f /usr/bin/java | sed "s:bin/java::")
+export PATH=${HADOOP_HOME}/bin/:$PATH
+export HADOOP_CLASSPATH="$(hadoop classpath):${SPARK_HOME}/jars/gcs-connector-latest-hadoop2.jar"
+
+export GOOGLE_APPLICATION_CREDENTIALS=${HOME}/gcs-key.json
+export GS_PROJECT_ID=ucb-datahub-2018
+export SPARK_DIST_CLASSPATH=${HADOOP_CLASSPATH}"
+
+exec "$@"

--- a/deployments/w261/image/start
+++ b/deployments/w261/image/start
@@ -5,13 +5,14 @@ set -euo pipefail
 export HADOOP_HOME=${CONDA_DIR}/hadoop
 export SPARK_HOME=${CONDA_DIR}/spark
 
-# Create a bunch of varialbes for testing in Hadoop and setting up GCP/GCS configs
+# Setup spark / hadoop / java related environments
 export JAVA_HOME=$(readlink -f /usr/bin/java | sed "s:bin/java::")
 export PATH=${HADOOP_HOME}/bin/:$PATH
 export HADOOP_CLASSPATH="$(hadoop classpath):${SPARK_HOME}/jars/gcs-connector-latest-hadoop2.jar"
+export SPARK_DIST_CLASSPATH=${HADOOP_CLASSPATH}
 
+# FIXME: These environment variables should be dynamically set
 export GOOGLE_APPLICATION_CREDENTIALS=${HOME}/gcs-key.json
 export GS_PROJECT_ID=ucb-datahub-2018
-export SPARK_DIST_CLASSPATH=${HADOOP_CLASSPATH}
 
 exec "$@"


### PR DESCRIPTION
$HOME is made invisible when user directory is mounted
over it.

We also export our environment variables from the 'start'
script, which is run before the user's notebook starts,
rather than in .bashrc (since .bashrc isn't respected
by repo2docker yet)