### PR TITLE
Give w261 user pods rights on their own namespace

### DIFF
--- a/deployments/w261/config/common.yaml
+++ b/deployments/w261/config/common.yaml
@@ -8,6 +8,9 @@ jupyterhub:
           - yuvipanda
 
   singleuser:
+    # HACK: Temporarily give user pods lots of k8s access in their
+    # own namespace. We will lock this down later before productionizing.
+    serviceAccountName: default
     memory:
       guarantee: 512M
       limit: 2G


### PR DESCRIPTION
This lets @jameswinegar test out spark on the k8s cluster.
We'll lock this down eventually before going live.