### PR TITLE
Enable NetworkPolicy in the helm chart

### DIFF
--- a/docs/topic/cluster-config.rst
+++ b/docs/topic/cluster-config.rst
@@ -27,7 +27,7 @@ the currently favored configuration.
 
 .. code:: bash
 
-   gcloud container clusters create
+   gcloud container clusters create \
         --enable-ip-alias \
         --enable-autoscaling \
         --max-nodes=20 --min-nodes=2 \
@@ -36,7 +36,17 @@ the currently favored configuration.
         --disk-size=100 --disk-type=pd-standard \
         --machine-type=n1-highmem-8 \
         --cluster-version latest \
+        --no-enable-autoupgrade \
+        --enable-network-policy \
+        --create-subnetwork="" \
         <cluster-name>
+
+.. note::
+
+   The following flags have been recently added for additional security.
+   All new clusters created should have them, but older clusters might not.
+
+     #. ``--enable-network-policy``
 
 We will try explain the various arguments to this command line invocation.
 
@@ -143,6 +153,25 @@ Cluster version
 
 GKE automatically upgrades cluster masters, so there is generally no harm in being
 on the latest version available.
+
+Node autoupgrades
+-----------------
+
+When node autoupgrades are enabled, GKE will automatically try to
+upgrade our nodes whenever needed (our GKE version falling off the
+support window, security issues, etc). However, since we run stateful
+workloads, we *disable* this right now so we can do the upgrades
+manually.
+
+Network Policy
+--------------
+
+Kubernetes `Network Policy <https://kubernetes.io/docs/concepts/services-networking/network-policies/>`_
+lets you firewall internal access inside a kubernetes cluster, whitelisting
+only the flows you want. The JupyterHub chart we use supports setting up
+appropriate NetworkPolicy objects it needs, so we should turn it on for
+additional security depth. Note that any extra in-cluster services we run
+*must* have a NetworkPolicy set up for them to work reliabliy.
 
 Cluster name
 ------------

--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -11,9 +11,29 @@ jupyterhub:
     https:
       letsencrypt:
         contactEmail: yuvipanda@berkeley.edu
+    networkPolicy:
+      enabled: true
   singleuser:
     defaultUrl: "/tree"
+    networkPolicy:
+      # In clusters with NetworkPolicy enabled, do not
+      # allow outbound internet access that's not DNS, HTTP or HTTPS
+      # We can override this on a case to case basesi where
+      # required.
+      enabled: true
+      egress:
+        - ports:
+            - port: 53
+              protocol: UDP
+        - ports:
+            - port: 80
+              protocol: TCP
+        - ports:
+            - port: 443
+              protocol: TCP
   hub:
+    networkPolicy:
+      enabled: true
     extraConfig:
       01-custom-attr-spawner: |
         from kubespawner import KubeSpawner


### PR DESCRIPTION
We enable NetworkPolicy in the z2jh helm chart
(http://z2jh.jupyter.org/en/latest/security.html#kubernetes-network-policies).

This provides basic firewalling for the various components we run,
making sure they are only making the network requests they are
supposed to make.

1. Hub can only talk to the proxy and user pods
2. Proxy can only talk to the hub and user pods
3. User pods can only talk to hub, proxy and port 53/80/443 to
   everything else.

We might need to relax these permissions later for other
reasons, but it's a good start.

The cluster on which we currently run most on-campus hubs and
data8x hub don't have NetworkPolicy enforcement (https://cloud.google.com/kubernetes-engine/docs/how-to/network-policy)
enabled, so this should be a no-op there.  The 'summer-2019' cluster
created for hubs this summer *does* have it enabled, so we can
migrate the hubs and make sure they are working over the summer.