### PR TITLE
Move w261 to 'summer' cluster

### DIFF
--- a/deployments/w261/hubploy.yaml
+++ b/deployments/w261/hubploy.yaml
@@ -11,5 +11,5 @@ cluster:
   gcloud:
     project: ucb-datahub-2018
     service_key: gke-key.json
-    cluster: w261
+    cluster: summer-2019
     zone: us-central1


### PR DESCRIPTION
- Move w261 to a cluster where other summer hubs
  will also be running
- This cluster has NetworkPolicy enabled, making things
  a little more secure
- Turns out creating 3 clusters with ip aliasing in
  the same 'subnet' is a problem, and it is gonna take
  too long to figure that one out.