### PR TITLE
Bump hubploy version

### DIFF
--- a/deployments/datahub/image/requirements.txt
+++ b/deployments/datahub/image/requirements.txt
@@ -19,7 +19,7 @@ appmode==0.4.0
 nbresuse==0.3.1
 #
 # r
-jupyter-server-proxy==1.0.0
+jupyter-server-proxy==1.0.1
 jupyter-rsession-proxy==1.0b6
 #
 # cogsci88;

--- a/deployments/math124/image/requirements.txt
+++ b/deployments/math124/image/requirements.txt
@@ -1,4 +1,4 @@
-notebook==5.7.6
+notebook==5.7.8
 nbgitpuller==0.6.1
 nbresuse==0.3.1
 # For PyPlot

--- a/deployments/prob140/image/Dockerfile
+++ b/deployments/prob140/image/Dockerfile
@@ -18,8 +18,8 @@ RUN apt-get update --yes
 RUN apt-get install --yes \
             libdpkg-perl \
             python3.6 \
-            python3.6-venv \
             python3.6-dev \
+            python3.6-venv \
             python3-venv \
             tar \
             vim \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-git+https://github.com/yuvipanda/hubploy.git@8b37dbb4d255c2f225894dd2ddef9cbc188e9d8b
+git+https://github.com/yuvipanda/hubploy.git@7015b4db0da8c04cdbe5edaeecf9d74ae0d45e66
 pygithub


### PR DESCRIPTION
This puts contents of the built image directory into
/srv/repo, so we can install things into that location that will
continue to be available when user is running the container
without being overmounted by $HOME

Does a bunch of minor modifications to various images to make
sure new hubploy works fine with our hub setup.