### PR TITLE
Collect hub prometheus metrics

### DIFF
--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -136,3 +136,7 @@ jupyterhub:
         # Make sure working directory is ${HOME}
         # hubploy has a bug where it unconditionally puts workingdir to be /srv/repo
         c.KubeSpawner.working_dir = '/home/jovyan'
+      05-prometheus: |
+        # Allow unauthenticated prometheus requests
+        # Otherwise our prometheus server can't get to these
+        c.JupyterHub.authenticate_prometheus = False


### PR DESCRIPTION
JupyterHub v1 put them behind auth. Our prometheus
servers don't have access to this auth, so they
can't collect these metrics.

We don't leak usernames or anything like that here, so it'
fine to expose these