### PR TITLE
Use nbpdfexport for PDF export

### DIFF
--- a/deployments/canvas-test/image/apt.txt
+++ b/deployments/canvas-test/image/apt.txt
@@ -1,3 +1,3 @@
 texlive-xetex
 texlive-fonts-recommended
-texlive-full
+texlive-generic-recommended

--- a/deployments/r/image/Dockerfile
+++ b/deployments/r/image/Dockerfile
@@ -17,10 +17,18 @@ ENV LD_LIBRARY_PATH /usr/local/lib/R/lib
 ENV HOME /home/${NB_USER}
 WORKDIR ${HOME}
 
+# Setup a LaTeX that notebook can use
+# texlive-local seems to be installed by rocker, and isn't enough
 RUN apt-get update && \
-    apt-get install --yes --install-recommends \
-        python3-venv python3-dev texlive-full && \
-    apt-get purge && \
+    apt-get purge --yes texlive-local && \
+    apt-get install --yes texlive-xetex texlive-fonts-recommended texlive-generic-recommended && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+
+RUN apt-get update && \
+    apt-get install --yes \
+        python3-venv python3-dev && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/deployments/r/image/Dockerfile
+++ b/deployments/r/image/Dockerfile
@@ -18,7 +18,8 @@ ENV HOME /home/${NB_USER}
 WORKDIR ${HOME}
 
 RUN apt-get update && \
-    apt-get -y install python3-venv python3-dev texlive-full && \
+    apt-get install --yes --install-recommends \
+        python3-venv python3-dev texlive-full && \
     apt-get purge && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/deployments/r/image/Dockerfile
+++ b/deployments/r/image/Dockerfile
@@ -3,6 +3,8 @@ FROM rocker/geospatial:3.6.0
 ENV NB_USER rstudio
 ENV NB_UID 1000
 ENV CONDA_DIR /srv/conda
+# FIXME: Why do I need to set this here manually?
+ENV REPO_DIR /srv/repo
 
 # Set ENV for all programs...
 ENV PATH ${CONDA_DIR}/bin:$PATH
@@ -45,13 +47,12 @@ RUN pip install --no-cache-dir \
                 nbpdfexport==0.1
 
 # Ship headless chrome in the image
+# FIXME: This should install into /srv/conda, not $HOME
 RUN pyppeteer-install
 
 # Install IRKernel
 RUN R --quiet -e "install.packages('IRkernel')" && \
-    R --quiet -e "IRkernel::installspec(prefix='${VENV_DIR}')"
-
-COPY --chown=rstudio:rstudio . ${REPO_DIR}
+    R --quiet -e "IRkernel::installspec(prefix='${CONDA_DIR}')"
 
 # Install some R libraries that aren't in the base image
 COPY --chown=rstudio extras.d  /tmp/extras.d
@@ -66,9 +67,9 @@ RUN chmod -R +x /tmp/extras.d && \
 RUN tail /tmp/r-custom-packages.log
 RUN rm /tmp/r-custom-packages.log
 
-# Install requirements.txt if it exists
-RUN [ -f ${REPO_DIR}/requirements.txt ] && \
-    pip install --no-cache-dir -r ${REPO_DIR}/requirements.txt
+COPY --chown=rstudio:rstudio . ${REPO_DIR}
+
+RUN pip install --no-cache-dir -r ${REPO_DIR}/requirements.txt
 
 # Execute PostBuild if it exists
 RUN [ -f ${REPO_DIR}/postBuild ] && chmod +x ${REPO_DIR}/postBuild && ${REPO_DIR}/postBuild

--- a/deployments/r/image/Dockerfile
+++ b/deployments/r/image/Dockerfile
@@ -44,7 +44,7 @@ RUN pip install --no-cache-dir \
                 jupyterhub==1.0.0 \
                 jupyterlab==0.35.6 \
                 notebook==5.7.8 \
-                nbpdfexport==0.1
+                nbpdfexport==0.2.1
 
 # Set up nbpdf dependencies
 ENV PYPPETEER_HOME /srv/conda

--- a/deployments/r/image/Dockerfile
+++ b/deployments/r/image/Dockerfile
@@ -2,11 +2,10 @@ FROM rocker/geospatial:3.6.0
 
 ENV NB_USER rstudio
 ENV NB_UID 1000
-ENV VENV_DIR /srv/venv
-ENV REPO_DIR /srv/repo
+ENV CONDA_DIR /srv/conda
 
 # Set ENV for all programs...
-ENV PATH ${VENV_DIR}/bin:$PATH
+ENV PATH ${CONDA_DIR}/bin:$PATH
 # And set ENV for R! It doesn't read from the environment...
 RUN echo "PATH=${PATH}" >> /usr/local/lib/R/etc/Renviron
 
@@ -33,32 +32,17 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-RUN apt-get update && \
-    apt-get install --yes \
-        python3-venv python3-dev && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
-
-# Create a venv dir owned by unprivileged user & set up notebook in it
-# This allows non-root to install python libraries if required
-RUN mkdir -p ${VENV_DIR} && chown -R ${NB_USER} ${VENV_DIR}
-RUN mkdir -p ${REPO_DIR} && chown -R ${NB_USER} ${REPO_DIR}
+COPY install-miniconda.bash /tmp/install-miniconda.bash
+RUN /tmp/install-miniconda.bash
 
 USER ${NB_USER}
 
-
-RUN python3 -m venv ${VENV_DIR}
-
-# Explicitly install a new enough version of pip
-RUN ${VENV_DIR}/bin/pip3 install --no-cache-dir \
-                         pip==19.1.1
-
-RUN ${VENV_DIR}/bin/pip3 install --no-cache-dir \
-                         jupyter-rsession-proxy==1.0b6 \
-                         jupyterhub==1.0.0 \
-                         jupyterlab==0.35.6 \
-                         notebook==5.7.8 \
-                         nbpdfexport==0.1
+RUN pip install --no-cache-dir \
+                jupyter-rsession-proxy==1.0b6 \
+                jupyterhub==1.0.0 \
+                jupyterlab==0.35.6 \
+                notebook==5.7.8 \
+                nbpdfexport==0.1
 
 # Ship headless chrome in the image
 RUN pyppeteer-install
@@ -84,7 +68,7 @@ RUN rm /tmp/r-custom-packages.log
 
 # Install requirements.txt if it exists
 RUN [ -f ${REPO_DIR}/requirements.txt ] && \
-    ${VENV_DIR}/bin/pip3 install --no-cache-dir -r ${REPO_DIR}/requirements.txt
+    pip install --no-cache-dir -r ${REPO_DIR}/requirements.txt
 
 # Execute PostBuild if it exists
 RUN [ -f ${REPO_DIR}/postBuild ] && chmod +x ${REPO_DIR}/postBuild && ${REPO_DIR}/postBuild

--- a/deployments/r/image/Dockerfile
+++ b/deployments/r/image/Dockerfile
@@ -47,7 +47,7 @@ RUN pip install --no-cache-dir \
                 nbpdfexport==0.1
 
 # Ship headless chrome in the image
-# FIXME: This should install into /srv/conda, not $HOME
+ENV PYPPETEER_HOME /srv/conda
 RUN pyppeteer-install
 
 # Install IRKernel

--- a/deployments/r/image/Dockerfile
+++ b/deployments/r/image/Dockerfile
@@ -46,9 +46,10 @@ RUN pip install --no-cache-dir \
                 notebook==5.7.8 \
                 nbpdfexport==0.1
 
-# Ship headless chrome in the image
+# Set up nbpdf dependencies
 ENV PYPPETEER_HOME /srv/conda
 RUN pyppeteer-install
+RUN jupyter bundlerextension enable nbpdfexport.bundler --sys-prefix --py
 
 # Install IRKernel
 RUN R --quiet -e "install.packages('IRkernel')" && \

--- a/deployments/r/image/Dockerfile
+++ b/deployments/r/image/Dockerfile
@@ -17,14 +17,21 @@ ENV LD_LIBRARY_PATH /usr/local/lib/R/lib
 ENV HOME /home/${NB_USER}
 WORKDIR ${HOME}
 
-# Setup a LaTeX that notebook can use
-# texlive-local seems to be installed by rocker, and isn't enough
+# Install packages needed by nbpdfexport
 RUN apt-get update && \
-    apt-get purge --yes texlive-local && \
-    apt-get install --yes texlive-xetex texlive-fonts-recommended texlive-generic-recommended && \
+    apt-get install --yes \
+            libx11-xcb1 \
+            libxtst6 \
+            libxrandr2 \
+            libasound2 \
+            libpangocairo-1.0-0 \
+            libatk1.0-0 \
+            libatk-bridge2.0-0 \
+            libgtk-3-0 \
+            libnss3 \
+            libxss1 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
-
 
 RUN apt-get update && \
     apt-get install --yes \
@@ -39,17 +46,6 @@ RUN mkdir -p ${REPO_DIR} && chown -R ${NB_USER} ${REPO_DIR}
 
 USER ${NB_USER}
 
-# Install some R libraries that aren't in the base image
-COPY --chown=rstudio extras.d  /tmp/extras.d
-# CircleCI stops printing output at 40k chars.
-# We send stdout to a log file, and tail it a bit
-# FIXME: Find something less sucky
-# another hubploy #1
-RUN chmod -R +x /tmp/extras.d && \
-	run-parts /tmp/extras.d > /tmp/r-custom-packages.log 2>&1 && \
-    true || ( echo FAIL ; tail /tmp/r-custom-packages.log ; false )
-RUN tail /tmp/r-custom-packages.log
-RUN rm /tmp/r-custom-packages.log
 
 RUN python3 -m venv ${VENV_DIR}
 
@@ -61,13 +57,30 @@ RUN ${VENV_DIR}/bin/pip3 install --no-cache-dir \
                          jupyter-rsession-proxy==1.0b6 \
                          jupyterhub==1.0.0 \
                          jupyterlab==0.35.6 \
-                         notebook==5.7.8
+                         notebook==5.7.8 \
+                         nbpdfexport==0.1
+
+# Ship headless chrome in the image
+RUN pyppeteer-install
 
 # Install IRKernel
 RUN R --quiet -e "install.packages('IRkernel')" && \
     R --quiet -e "IRkernel::installspec(prefix='${VENV_DIR}')"
 
 COPY --chown=rstudio:rstudio . ${REPO_DIR}
+
+# Install some R libraries that aren't in the base image
+COPY --chown=rstudio extras.d  /tmp/extras.d
+# CircleCI stops printing output at 40k chars.
+# We send stdout to a log file, and tail it a bit
+# FIXME: Find something less sucky
+# another hubploy #1
+RUN chmod -R +x /tmp/extras.d && \
+	run-parts /tmp/extras.d > /tmp/r-custom-packages.log 2>&1 && \
+    true || ( echo FAIL ; tail /tmp/r-custom-packages.log ; false )
+
+RUN tail /tmp/r-custom-packages.log
+RUN rm /tmp/r-custom-packages.log
 
 # Install requirements.txt if it exists
 RUN [ -f ${REPO_DIR}/requirements.txt ] && \

--- a/deployments/r/image/install-miniconda.bash
+++ b/deployments/r/image/install-miniconda.bash
@@ -47,7 +47,7 @@ fi
 # which seems to result in some effective pinning of packages in the initial env,
 # which we don't intend.
 # this file must not be *removed*, however
-echo '' > ${NB_PYTHON_PREFIX}/conda-meta/history
+echo '' > ${CONDA_DIR}/conda-meta/history
 
 # Clean things out!
 conda clean --all -f -y
@@ -61,4 +61,3 @@ rm -rf /root/.cache
 chown -R $NB_USER:$NB_USER ${CONDA_DIR}
 
 conda list -n root
-conda list -p ${NB_PYTHON_PREFIX}

--- a/deployments/r/image/install-miniconda.bash
+++ b/deployments/r/image/install-miniconda.bash
@@ -1,0 +1,64 @@
+#!/bin/bash
+# This downloads and installs a pinned version of miniconda
+set -ex
+
+cd $(dirname $0)
+MINICONDA_VERSION=4.6.14
+CONDA_VERSION=4.6.14
+# Only MD5 checksums are available for miniconda
+# Can be obtained from https://repo.continuum.io/miniconda/
+MD5SUM="718259965f234088d785cad1fbd7de03"
+
+URL="https://repo.continuum.io/miniconda/Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh"
+INSTALLER_PATH=/tmp/miniconda-installer.sh
+
+# make sure we don't do anything funky with user's $HOME
+# since this is run as root
+unset HOME
+
+wget --quiet $URL -O ${INSTALLER_PATH}
+chmod +x ${INSTALLER_PATH}
+
+# check md5 checksum
+if ! echo "${MD5SUM}  ${INSTALLER_PATH}" | md5sum  --quiet -c -; then
+    echo "md5sum mismatch for ${INSTALLER_PATH}, exiting!"
+    exit 1
+fi
+
+bash ${INSTALLER_PATH} -b -p ${CONDA_DIR}
+export PATH="${CONDA_DIR}/bin:$PATH"
+
+# Allow easy direct installs from conda forge
+conda config --system --add channels conda-forge
+
+# Do not attempt to auto update conda or dependencies
+conda config --system --set auto_update_conda false
+conda config --system --set show_channel_urls true
+
+# bug in conda 4.3.>15 prevents --set update_dependencies
+echo 'update_dependencies: false' >> ${CONDA_DIR}/.condarc
+
+# install conda itself
+if [[ "${CONDA_VERSION}" != "${MINICONDA_VERSION}" ]]; then
+    conda install -yq conda==${CONDA_VERSION}
+fi
+
+# empty conda history file,
+# which seems to result in some effective pinning of packages in the initial env,
+# which we don't intend.
+# this file must not be *removed*, however
+echo '' > ${NB_PYTHON_PREFIX}/conda-meta/history
+
+# Clean things out!
+conda clean --all -f -y
+
+# Remove the big installer so we don't increase docker image size too much
+rm ${INSTALLER_PATH}
+
+# Remove the pip cache created as part of installing miniconda
+rm -rf /root/.cache
+
+chown -R $NB_USER:$NB_USER ${CONDA_DIR}
+
+conda list -n root
+conda list -p ${NB_PYTHON_PREFIX}

--- a/deployments/r/image/postBuild
+++ b/deployments/r/image/postBuild
@@ -2,5 +2,5 @@
 set -euo pipefail
 
 # Create ipython config directory if it doesn't exist
-mkdir -p ${VENV_DIR}/etc/ipython
-cp ${REPO_DIR}/ipython_config.py ${VENV_DIR}/etc/ipython/ipython_config.py
+mkdir -p ${CONDA_DIR}/etc/ipython
+cp ${REPO_DIR}/ipython_config.py ${CONDA_DIR}/etc/ipython/ipython_config.py


### PR DESCRIPTION
Rather than figuring out the magic incantations that
let notebook to PDF work via LaTeX, we instead use
[nbpdfexport](https://github.com/yuvipanda/nbpdfexport)

It also involved a detour into installing Python via
conda, since nbpdfexport depends on pyppeteer which
requires Python 3.6+, while rocker images are based off
debian stretch & hence ship with Python 3.5