### PR TITLE
Set node selectors for core / user pool nodes

### DIFF
--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -1,16 +1,25 @@
+userNodeSelector: &userNodeSelector
+  cloud.google.com/gke-nodepool: default-pool
+
+coreNodeSelector: &coreNodeSelector
+  cloud.google.com/gke-nodepool: user-pool
+
 nfsPVC:
   enabled: true
 jupyterhub:
   scheduling:
     userScheduler:
+      nodeSelector: *coreNodeSelector
       enabled: true
   proxy:
+    nodeSelector: *coreNodeSelector
     https:
       letsencrypt:
         contactEmail: yuvipanda@berkeley.edu
     networkPolicy:
       enabled: true
   singleuser:
+    nodeSelector: *userNodeSelector
     defaultUrl: /tree
     networkPolicy:
       # In clusters with NetworkPolicy enabled, do not
@@ -47,6 +56,7 @@ jupyterhub:
       tag: '0.1.0-80d0432'
     networkPolicy:
       enabled: true
+    nodeSelector: *coreNodeSelector
     extraEnv:
       # This is unfortunately still needed by canvas auth
       OAUTH2_AUTHORIZE_URL: https://bcourses.berkeley.edu/login/oauth2/auth


### PR DESCRIPTION
We want two pools:

1. Core pool, just hub / proxy / scheduler pods
2. User pool, all user servers

(2) is a lot more dynamic than (1), and so we gain
much better efficiency in autoscaling.

This is stolen from github.com/jupyterhub/mybinder.org-deploy