### PR TITLE
Turn off continuous prePuller for staging

### DIFF
--- a/deployments/bcourses/config/staging.yaml
+++ b/deployments/bcourses/config/staging.yaml
@@ -1,4 +1,7 @@
 jupyterhub:
+  prePuller:
+    continuous:
+      enabled: false
   proxy:
     service:
       # make the IP static in google cloud console so we won't lose it

--- a/deployments/data100/config/staging.yaml
+++ b/deployments/data100/config/staging.yaml
@@ -1,4 +1,7 @@
 jupyterhub:
+  prePuller:
+    continuous:
+      enabled: false
   proxy:
     https:
       hosts:

--- a/deployments/data8x/config/staging.yaml
+++ b/deployments/data8x/config/staging.yaml
@@ -1,4 +1,7 @@
 jupyterhub:
+  prePuller:
+    continuous:
+      enabled: false
   proxy:
     service:
       loadBalancerIP: 104.198.75.230

--- a/deployments/datahub/config/staging.yaml
+++ b/deployments/datahub/config/staging.yaml
@@ -1,4 +1,7 @@
 jupyterhub:
+  prePuller:
+    continuous:
+      enabled: false
   proxy:
     service:
       loadBalancerIP: 104.197.27.164

--- a/deployments/external/config/staging.yaml
+++ b/deployments/external/config/staging.yaml
@@ -1,4 +1,7 @@
 jupyterhub:
+  prePuller:
+    continuous:
+      enabled: false
   proxy:
     service:
       loadBalancerIP: 35.225.68.82

--- a/deployments/julia/config/staging.yaml
+++ b/deployments/julia/config/staging.yaml
@@ -1,4 +1,7 @@
 jupyterhub:
+  prePuller:
+    continuous:
+      enabled: false
   proxy:
     service:
       loadBalancerIP: 35.226.84.4

--- a/deployments/prob140/config/staging.yaml
+++ b/deployments/prob140/config/staging.yaml
@@ -1,4 +1,7 @@
 jupyterhub:
+  prePuller:
+    continuous:
+      enabled: false
   proxy:
     service:
       loadBalancerIP: 35.226.250.22

--- a/deployments/r/config/staging.yaml
+++ b/deployments/r/config/staging.yaml
@@ -1,4 +1,7 @@
 jupyterhub:
+  prePuller:
+    continuous:
+      enabled: false
   proxy:
     service:
       loadBalancerIP: 34.68.107.18

--- a/deployments/template/{{cookiecutter.hub_name}}/config/staging.yaml
+++ b/deployments/template/{{cookiecutter.hub_name}}/config/staging.yaml
@@ -1,4 +1,7 @@
 jupyterhub:
+  prePuller:
+    continuous:
+      enabled: false
   proxy:
     # service:
       # make the IP static in google cloud console so we won't lose it

--- a/deployments/w261/config/staging.yaml
+++ b/deployments/w261/config/staging.yaml
@@ -1,4 +1,7 @@
 jupyterhub:
+  prePuller:
+    continuous:
+      enabled: false
   proxy:
     https:
       hosts:


### PR DESCRIPTION
This takes up one pod per node per hub, which
can be a lot. We turn it off for staging,
since we don't really care about performance of
new pod starts in staging after scale events