### PR TITLE
Move node selectors to individual hub configs

### DIFF
--- a/deployments/bcourses/config/common.yaml
+++ b/deployments/bcourses/config/common.yaml
@@ -5,6 +5,16 @@ nfsPVC:
     shareName: userhomes
 
 jupyterhub:
+  scheduling:
+    userScheduler:
+      nodeSelector:
+        cloud.google.com/gke-nodepool: core-pool
+  hub:
+    nodeSelector:
+      cloud.google.com/gke-nodepool: core-pool
+  proxy:
+    nodeSelector:
+      cloud.google.com/gke-nodepool: core-pool
   auth:
     type: lti
     admin:
@@ -15,6 +25,8 @@ jupyterhub:
           # List of other admin users
 
   singleuser:
+    nodeSelector:
+      cloud.google.com/gke-nodepool: user-pool
     initContainers:
       - name: volume-mount-hack
         image: busybox

--- a/deployments/datahub/config/common.yaml
+++ b/deployments/datahub/config/common.yaml
@@ -5,6 +5,16 @@ nfsPVC:
     shareName: export/pool0/homes
 
 jupyterhub:
+  scheduling:
+    userScheduler:
+      nodeSelector:
+        cloud.google.com/gke-nodepool: core-pool
+  hub:
+    nodeSelector:
+      cloud.google.com/gke-nodepool: core-pool
+  proxy:
+    nodeSelector:
+      cloud.google.com/gke-nodepool: core-pool
   auth:
     type: custom # This enables canvas auth
     admin:
@@ -77,6 +87,8 @@ jupyterhub:
           - shobhana
 
   singleuser:
+    nodeSelector:
+      cloud.google.com/gke-nodepool: user-pool
     initContainers:
       - name: volume-mount-hack
         image: busybox

--- a/deployments/julia/config/common.yaml
+++ b/deployments/julia/config/common.yaml
@@ -5,6 +5,16 @@ nfsPVC:
     shareName: export/pool0/homes
 
 jupyterhub:
+  scheduling:
+    userScheduler:
+      nodeSelector:
+        cloud.google.com/gke-nodepool: core-pool
+  hub:
+    nodeSelector:
+      cloud.google.com/gke-nodepool: core-pool
+  proxy:
+    nodeSelector:
+      cloud.google.com/gke-nodepool: core-pool
   auth:
     type: custom  # uses canvas auth, see hub/values.yaml
     admin:
@@ -16,6 +26,8 @@ jupyterhub:
           # List of other admin users
 
   singleuser:
+    nodeSelector:
+      cloud.google.com/gke-nodepool: user-pool
     initContainers:
       - name: volume-mount-hack
         image: busybox

--- a/deployments/prob140/config/common.yaml
+++ b/deployments/prob140/config/common.yaml
@@ -5,6 +5,16 @@ nfsPVC:
     shareName: userhomes
 
 jupyterhub:
+  scheduling:
+    userScheduler:
+      nodeSelector:
+        cloud.google.com/gke-nodepool: core-pool
+  hub:
+    nodeSelector:
+      cloud.google.com/gke-nodepool: core-pool
+  proxy:
+    nodeSelector:
+      cloud.google.com/gke-nodepool: core-pool
   auth:
     type: custom # Uses canvas auth
     admin:
@@ -30,6 +40,8 @@ jupyterhub:
           mem_limit: 1088M
 
   singleuser:
+    nodeSelector:
+      cloud.google.com/gke-nodepool: user-pool
     initContainers:
       - name: volume-mount-hack
         image: busybox

--- a/deployments/r/config/common.yaml
+++ b/deployments/r/config/common.yaml
@@ -6,7 +6,16 @@ nfsPVC:
 
 
 jupyterhub:
+  scheduling:
+    userScheduler:
+      nodeSelector:
+        cloud.google.com/gke-nodepool: core-pool
+  proxy:
+    nodeSelector:
+      cloud.google.com/gke-nodepool: core-pool
   hub:
+    nodeSelector:
+      cloud.google.com/gke-nodepool: core-pool
     extraConfig:
       # 04, since in hub/values.yaml we explicitly set it to /home/jovyan as 03
       04-rstudio-home: |
@@ -23,6 +32,8 @@ jupyterhub:
           # List of other admin users
 
   singleuser:
+    nodeSelector:
+      cloud.google.com/gke-nodepool: user-pool
     initContainers:
       - name: volume-mount-hack
         image: busybox

--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -1,18 +1,10 @@
-userNodeSelector: &userNodeSelector
-  cloud.google.com/gke-nodepool: user-pool
-
-coreNodeSelector: &coreNodeSelector
-  cloud.google.com/gke-nodepool: default-pool
-
 nfsPVC:
   enabled: true
 jupyterhub:
   scheduling:
     userScheduler:
-      nodeSelector: *coreNodeSelector
       enabled: true
   proxy:
-    nodeSelector: *coreNodeSelector
     chp:
       resources:
         requests:
@@ -35,7 +27,6 @@ jupyterhub:
     networkPolicy:
       enabled: true
   singleuser:
-    nodeSelector: *userNodeSelector
     defaultUrl: /tree
     networkPolicy:
       # In clusters with NetworkPolicy enabled, do not
@@ -72,7 +63,6 @@ jupyterhub:
       tag: '0.1.0-80d0432'
     networkPolicy:
       enabled: true
-    nodeSelector: *coreNodeSelector
     resources:
       requests:
         cpu: "0.25"


### PR DESCRIPTION
We don't have user / core pools in a lot of
other clusters, so it doesn't work in values.yaml