### PR TITLE
Run only 1 scheduler for staging

### DIFF
--- a/deployments/bcourses/config/staging.yaml
+++ b/deployments/bcourses/config/staging.yaml
@@ -1,4 +1,7 @@
 jupyterhub:
+  scheduling:
+    userScheduler:
+      replicas: 1
   prePuller:
     continuous:
       enabled: false

--- a/deployments/datahub/config/staging.yaml
+++ b/deployments/datahub/config/staging.yaml
@@ -1,4 +1,7 @@
 jupyterhub:
+  scheduling:
+    userScheduler:
+      replicas: 1
   prePuller:
     continuous:
       enabled: false

--- a/deployments/julia/config/staging.yaml
+++ b/deployments/julia/config/staging.yaml
@@ -1,4 +1,7 @@
 jupyterhub:
+  scheduling:
+    userScheduler:
+      replicas: 1
   prePuller:
     continuous:
       enabled: false

--- a/deployments/r/config/staging.yaml
+++ b/deployments/r/config/staging.yaml
@@ -1,4 +1,7 @@
 jupyterhub:
+  scheduling:
+    userScheduler:
+      replicas: 1
   prePuller:
     continuous:
       enabled: false

--- a/deployments/w261/config/staging.yaml
+++ b/deployments/w261/config/staging.yaml
@@ -1,4 +1,7 @@
 jupyterhub:
+  scheduling:
+    userScheduler:
+      replicas: 1
   prePuller:
     continuous:
       enabled: false


### PR DESCRIPTION
While it is sortof critical for production hubs, not so
for staging hubs