### PR TITLE
Install vioplot via install.packages.

### DIFF
--- a/deployments/r/image/extras.d/2019-fall-stat-131a.r
+++ b/deployments/r/image/extras.d/2019-fall-stat-131a.r
@@ -24,3 +24,6 @@ class_libs = c(
   # "vioplot", "0.3.0"
 )
 class_libs_install_version(class_name, class_libs)
+
+# 0.3.0 via mran 2019-07-05
+install.packages('vioplot')


### PR DESCRIPTION
This fails on rstudio #5108 when using devtools::install_version.