### PR TITLE
Switch to using newer, n1-highmem-16 nodepool

### DIFF
--- a/deployments/bcourses/config/common.yaml
+++ b/deployments/bcourses/config/common.yaml
@@ -29,7 +29,7 @@ jupyterhub:
 
   singleuser:
     nodeSelector:
-      cloud.google.com/gke-nodepool: user-pool
+      hub.jupyter.org/node-purpose: user
     initContainers:
       - name: volume-mount-hack
         image: busybox

--- a/deployments/data102/config/common.yaml
+++ b/deployments/data102/config/common.yaml
@@ -32,7 +32,7 @@ jupyterhub:
 
   singleuser:
     nodeSelector:
-      cloud.google.com/gke-nodepool: user-pool
+      hub.jupyter.org/node-purpose: user
     initContainers:
       - name: volume-mount-hack
         image: busybox

--- a/deployments/datahub/config/common.yaml
+++ b/deployments/datahub/config/common.yaml
@@ -142,7 +142,7 @@ jupyterhub:
           - zhoa210
   singleuser:
     nodeSelector:
-      cloud.google.com/gke-nodepool: user-pool
+      hub.jupyter.org/node-purpose: user
     storage:
       type: none
       extraVolumeMounts:

--- a/deployments/julia/config/common.yaml
+++ b/deployments/julia/config/common.yaml
@@ -30,7 +30,7 @@ jupyterhub:
 
   singleuser:
     nodeSelector:
-      cloud.google.com/gke-nodepool: user-pool
+      hub.jupyter.org/node-purpose: user
     initContainers:
       - name: volume-mount-hack
         image: busybox

--- a/deployments/prob140/config/common.yaml
+++ b/deployments/prob140/config/common.yaml
@@ -38,7 +38,7 @@ jupyterhub:
 
   singleuser:
     nodeSelector:
-      cloud.google.com/gke-nodepool: user-pool
+      hub.jupyter.org/node-purpose: user
     initContainers:
       - name: volume-mount-hack
         image: busybox

--- a/deployments/r/config/common.yaml
+++ b/deployments/r/config/common.yaml
@@ -70,7 +70,7 @@ jupyterhub:
 
   singleuser:
     nodeSelector:
-      cloud.google.com/gke-nodepool: user-pool
+      hub.jupyter.org/node-purpose: user
     initContainers:
       - name: volume-mount-hack
         image: busybox


### PR DESCRIPTION
Earlier we were using nodes that were much smaller, leading
to higher autoscaling activity. This caused pod startups
to be really slow in the mornings, since each node can only
have 40 users.

A new nodepool with size n1-highmem-16 has been created,
and has a more generic label applied to it. We direct new
user pods to this nodepool here.

We can't put this in values.yaml since the Azure hubs
do not have this label. We should have a cluster specific
values file soon