### PR TITLE
Increase datahub placeholders to 80

### DIFF
--- a/deployments/datahub/config/prod.yaml
+++ b/deployments/datahub/config/prod.yaml
@@ -23,4 +23,4 @@ jupyterhub:
   scheduling:
     userPlaceholder:
       enabled: true
-      replicas: 20
+      replicas: 80


### PR DESCRIPTION
We wanna have one full node as headroom, so this would
help with that.