### PR TITLE
Move core pods to their own nodepool

### DIFF
--- a/deployments/bcourses/config/common.yaml
+++ b/deployments/bcourses/config/common.yaml
@@ -11,13 +11,13 @@ jupyterhub:
   scheduling:
     userScheduler:
       nodeSelector:
-        cloud.google.com/gke-nodepool: default-pool
+        hub.jupyter.org/node-purpose=core
   hub:
     nodeSelector:
-      cloud.google.com/gke-nodepool: default-pool
+      hub.jupyter.org/node-purpose=core
   proxy:
     nodeSelector:
-      cloud.google.com/gke-nodepool: default-pool
+      hub.jupyter.org/node-purpose=core
   auth:
     type: lti
     admin:

--- a/deployments/data102/config/common.yaml
+++ b/deployments/data102/config/common.yaml
@@ -8,10 +8,10 @@ jupyterhub:
   scheduling:
     userScheduler:
       nodeSelector:
-        cloud.google.com/gke-nodepool: default-pool
+        hub.jupyter.org/node-purpose=core
   proxy:
     nodeSelector:
-      cloud.google.com/gke-nodepool: default-pool
+      hub.jupyter.org/node-purpose=core
   auth:
     type: google
     admin:
@@ -28,7 +28,7 @@ jupyterhub:
 
   hub:
     nodeSelector:
-      cloud.google.com/gke-nodepool: default-pool
+      hub.jupyter.org/node-purpose=core
 
   singleuser:
     nodeSelector:

--- a/deployments/datahub/config/common.yaml
+++ b/deployments/datahub/config/common.yaml
@@ -11,10 +11,10 @@ jupyterhub:
   scheduling:
     userScheduler:
       nodeSelector:
-        cloud.google.com/gke-nodepool: default-pool
+        hub.jupyter.org/node-purpose=core
   hub:
     nodeSelector:
-      cloud.google.com/gke-nodepool: default-pool
+      hub.jupyter.org/node-purpose=core
     extraConfigMap:
       # this should be migrated to custom.profiles when that works
       profiles:
@@ -30,7 +30,7 @@ jupyterhub:
         2019-fall-33469: {}
   proxy:
     nodeSelector:
-      cloud.google.com/gke-nodepool: default-pool
+      hub.jupyter.org/node-purpose=core
   auth:
     type: custom # This enables canvas auth
     admin:

--- a/deployments/julia/config/common.yaml
+++ b/deployments/julia/config/common.yaml
@@ -11,13 +11,13 @@ jupyterhub:
   scheduling:
     userScheduler:
       nodeSelector:
-        cloud.google.com/gke-nodepool: default-pool
+        hub.jupyter.org/node-purpose=core
   hub:
     nodeSelector:
-      cloud.google.com/gke-nodepool: default-pool
+      hub.jupyter.org/node-purpose=core
   proxy:
     nodeSelector:
-      cloud.google.com/gke-nodepool: default-pool
+      hub.jupyter.org/node-purpose=core
   auth:
     type: custom  # uses canvas auth, see hub/values.yaml
     admin:

--- a/deployments/prob140/config/common.yaml
+++ b/deployments/prob140/config/common.yaml
@@ -11,10 +11,10 @@ jupyterhub:
   scheduling:
     userScheduler:
       nodeSelector:
-        cloud.google.com/gke-nodepool: default-pool
+        hub.jupyter.org/node-purpose=core
   proxy:
     nodeSelector:
-      cloud.google.com/gke-nodepool: default-pool
+      hub.jupyter.org/node-purpose=core
   auth:
     type: google
     admin:
@@ -34,7 +34,7 @@ jupyterhub:
 
   hub:
     nodeSelector:
-      cloud.google.com/gke-nodepool: default-pool
+      hub.jupyter.org/node-purpose=core
 
   singleuser:
     nodeSelector:

--- a/deployments/r/config/common.yaml
+++ b/deployments/r/config/common.yaml
@@ -12,13 +12,13 @@ jupyterhub:
   scheduling:
     userScheduler:
       nodeSelector:
-        cloud.google.com/gke-nodepool: default-pool
+        hub.jupyter.org/node-purpose=core
   proxy:
     nodeSelector:
-      cloud.google.com/gke-nodepool: default-pool
+      hub.jupyter.org/node-purpose=core
   hub:
     nodeSelector:
-      cloud.google.com/gke-nodepool: default-pool
+      hub.jupyter.org/node-purpose=core
     extraConfigMap:
       # this should be migrated to custom.profiles when that works
       profiles:

--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -15,27 +15,21 @@ jupyterhub:
       resources:
         requests:
           memory: 64Mi
-          cpu: "0.05"
         limits:
           memory: 512Mi
-          cpu: "0.5"
   proxy:
     chp:
       resources:
         requests:
           memory: 320Mi
-          cpu: "0.1"
         limits:
           memory: 320Mi
-          cpu: "0.5"
     nginx:
       resources:
         requests:
           memory: 512Mi
-          cpu: "0.25"
         limits:
           memory: 512Mi
-          cpu: 1
     https:
       letsencrypt:
         contactEmail: yuvipanda@berkeley.edu
@@ -80,10 +74,8 @@ jupyterhub:
       enabled: true
     resources:
       requests:
-        cpu: "0.25"
         memory: 256Mi
       limits:
-        cpu: "1"
         memory: 1Gi
     extraEnv:
       # This is unfortunately still needed by canvas auth


### PR DESCRIPTION
We're using *4* n1-standard-8 nodes, which is 4x what I'd like us to use.
We aren't bottlenecked on CPU, so we switch to a highmem variant, and
remove CPU requests.