### PR TITLE
Cull idle kernels too

### DIFF
--- a/deployments/data102/config/common.yaml
+++ b/deployments/data102/config/common.yaml
@@ -48,6 +48,13 @@ jupyterhub:
       static:
         pvcName: home-nfs
         subPath: "_data102/{username}"
+      extraVolumes:
+        - name: etc-jupyter
+          configMap:
+            name: user-etc-jupyter
+      extraVolumeMounts:
+        - name: etc-jupyter
+          mountPath: /etc/jupyter
     memory:
       guarantee: 1G
       limit: 2G

--- a/deployments/datahub/config/common.yaml
+++ b/deployments/datahub/config/common.yaml
@@ -145,9 +145,6 @@ jupyterhub:
       hub.jupyter.org/node-purpose: user
     storage:
       type: none
-      extraVolumeMounts:
-        - name: home
-          mountPath: /home/jovyan
     memory:
       guarantee: 512M
       limit: 1G

--- a/deployments/datahub/config/prod.yaml
+++ b/deployments/datahub/config/prod.yaml
@@ -5,10 +5,20 @@ nfsMounter:
 jupyterhub:
   singleuser:
     storage:
+      # Since these are lists, we can not use any merging behavior
+      # grrr
       extraVolumes:
+        - name: etc-jupyter
+          configMap:
+            name: user-etc-jupyter
         - name: home
           hostPath:
             path: /data/homes/prod/{username}
+      extraVolumeMounts:
+        - name: etc-jupyter
+          mountPath: /etc/jupyter
+        - name: home
+          mountPath: /home/jovyan
   proxy:
     service:
       loadBalancerIP: 35.232.190.188

--- a/deployments/datahub/config/staging.yaml
+++ b/deployments/datahub/config/staging.yaml
@@ -4,10 +4,20 @@ nfsMounter:
 jupyterhub:
   singleuser:
     storage:
+      # Since these are lists, we can not use any merging behavior
+      # grrr
       extraVolumes:
+        - name: etc-jupyter
+          configMap:
+            name: user-etc-jupyter
         - name: home
           hostPath:
             path: /data/homes/staging/{username}
+      extraVolumeMounts:
+        - name: etc-jupyter
+          mountPath: /etc/jupyter
+        - name: home
+          mountPath: /home/jovyan
   scheduling:
     userPlaceholder:
       enabled: true

--- a/deployments/prob140/config/common.yaml
+++ b/deployments/prob140/config/common.yaml
@@ -54,6 +54,13 @@ jupyterhub:
       static:
         pvcName: home-nfs
         subPath: "_prob140/{username}"
+      extraVolumes:
+        - name: etc-jupyter
+          configMap:
+            name: user-etc-jupyter
+      extraVolumeMounts:
+        - name: etc-jupyter
+          mountPath: /etc/jupyter
     memory:
       guarantee: 512M
       limit: 1G

--- a/deployments/r/config/common.yaml
+++ b/deployments/r/config/common.yaml
@@ -87,6 +87,13 @@ jupyterhub:
       static:
         pvcName: home-nfs
         subPath: "{username}"
+      extraVolumes:
+        - name: etc-jupyter
+          configMap:
+            name: user-etc-jupyter
+      extraVolumeMounts:
+        - name: etc-jupyter
+          mountPath: /etc/jupyter
     defaultUrl: "/rstudio"
     memory:
       guarantee: 512M

--- a/hub/templates/jupyter-notebook-config.yaml
+++ b/hub/templates/jupyter-notebook-config.yaml
@@ -1,0 +1,18 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: user-etc-jupyter
+  labels:
+    app: jupyterhub
+    component: etc-jupyter
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+data:
+  {{- range $name, $content := .Values.etcJupyter }}
+  {{- if eq (typeOf $content) "string" }}
+  {{ $name }}: |
+    {{- $content | nindent 4 }}
+  {{- else }}
+  {{ $name }}: {{ $content | toJson | quote }}
+  {{- end }}
+  {{- end }}

--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -1,3 +1,19 @@
+etcJupyter:
+  jupyter_notebook_config.json:
+    # if a user leaves a notebook with a running kernel,
+    # the effective idle timeout will typically be CULL_TIMEOUT + CULL_KERNEL_TIMEOUT
+    # as culling the kernel will register activity,
+    # resetting the no_activity timer for the server as a whole
+    MappingKernelManager:
+      # shutdown kernels after no activity
+      cull_idle_timeout: 3600
+      # check for idle kernels this often
+      cull_interval: 300
+      # a kernel with open connections but no activity still counts as idle
+      # this is what allows us to shutdown servers
+      # when people leave a notebook open and wander off
+      cull_connected: true
+
 nfsMounter:
   enabled: true
 


### PR DESCRIPTION
The idle culler for user servers seems to miss several
user pods for days. Preliminary investigation makes me hypothesize
that even though they have no active users, there is a connected
notebook because the user has kept a notebook tab open & walked
away.

We steal the idea from
https://github.com/jupyterhub/mybinder.org-deploy/pull/502,
and the implementation from
https://github.com/jupyterhub/mybinder.org-deploy/pull/792.

We set less harsh measures than mybinder:

1. We only stop the kernel, but do not kill the server. The
   idle jupyterhub culler can do that job for us.
2. Our timeouts are an hour, not 10 minutes

My hope is that this will make scaling down more efficient,
since our culler will be able to kill unused pods better.