### PR TITLE
Add a user placeholder rebalancer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
           name: Install base apt packages
           command: |
             apt-get update --yes -qq
-            apt-get install --yes -qq python3 python3-venv git-crypt jq
+            apt-get install --yes -qq python3 python3-venv git-crypt jq docker.io
       - checkout
       - restore_cache:
           keys:
@@ -39,6 +39,12 @@ jobs:
               COMMIT_RANGE=$(./.circleci/get-commit-range.py)
               echo ${COMMIT_RANGE}
               echo "export COMMIT_RANGE='${COMMIT_RANGE}'" >> ${BASH_ENV}
+
+      - run:
+          name: Test building support images we need
+          command: |
+            chartpress --commit-range ${COMMIT_RANGE}
+
       - run:
           name: Test building datahub image if needed
           command: |
@@ -93,7 +99,7 @@ jobs:
           name: Install base apt packages
           command: |
             apt-get update -qq --yes
-            apt-get install -qq --yes python3 python3-venv git-crypt lsb-release apt-transport-https
+            apt-get install -qq --yes python3 python3-venv git-crypt lsb-release apt-transport-https docker.io
       - checkout
       # Download and cache dependencies
       - restore_cache:
@@ -219,6 +225,11 @@ jobs:
               --grafana-url http://grafana.datahub.berkeley.edu\
               --tag deployment-start \
               "$(echo -en ${PULL_REQUEST_TITLE}\\n\\n${AUTHOR_NAME}: https://github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/pull/${PULL_REQUEST_ID})"
+
+      - run:
+          name: Build support images we need
+          command: |
+            chartpress --push --commit-range ${CIRCLE_BRANCH}...HEAD
 
       - run:
           name: Deploy datahub

--- a/chartpress.yaml
+++ b/chartpress.yaml
@@ -1,4 +1,9 @@
 charts:
+  - name: support
+    imagePrefix: gcr.io/ucb-datahub-2018/jupyterhub-support-
+    images:
+      rebalancer:
+        valuesPath: rebalancer.image
   - name: hub
     imagePrefix: gcr.io/ucb-datahub-2018/jupyterhub-
     images:

--- a/images/rebalancer/Dockerfile
+++ b/images/rebalancer/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.7.4-slim-buster
+
+ADD requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
+
+ADD . .
+
+CMD ['python3', 'rebalancer.py']

--- a/images/rebalancer/rebalancer.py
+++ b/images/rebalancer/rebalancer.py
@@ -46,6 +46,7 @@ async def label_newest_node(v1, namespace, user_node_selector, attractor_label):
             if attractor_label not in node.metadata.labels:
                 # Our youngest node doesn't have this label!
                 node.metadata.labels[attractor_label] = 'true'
+                # FIXME: A loop here to do conflict detection & resolution
                 await v1.patch_node(node.metadata.name, node)
                 logging.info(f'Adding label to {node.metadata.name}')
                 labeling_event = True
@@ -53,6 +54,7 @@ async def label_newest_node(v1, namespace, user_node_selector, attractor_label):
             if attractor_label in node.metadata.labels:
                 # Setting value to None removes the labels
                 node.metadata.labels[attractor_label] = None
+                # FIXME: A loop here to do conflict detection & resolution
                 await v1.patch_node(node.metadata.name, node)
                 logging.info(f'Removing label from {node.metadata.name}')
                 labeling_event = True
@@ -60,6 +62,8 @@ async def label_newest_node(v1, namespace, user_node_selector, attractor_label):
     if labeling_event:
         logging.info('Deleting placeholder pods to move them to newest node')
         await asyncio.sleep(2)
+        # FIXME: Only delete placeholder pods that aren't already on the newest node!
+        #        Since placeholder pods trigger scale ups, there must be some there
         await v1.delete_collection_namespaced_pod(namespace, label_selector='component=user-placeholder')
     else:
         logging.info(f'Newest node {ready_nodes[0].metadata.name} already has appropriate label, no action performed')

--- a/images/rebalancer/rebalancer.py
+++ b/images/rebalancer/rebalancer.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""
+Rebalance placeholder pods so they are always on the newest node
+
+When a new node is brought up by the autoscaler, it doesn't have any of our
+user images. So for about 10 mintues (which is how long our biggest image takes to pull!),
+user pods that end up on that node time out (which is 5 minutes now). This is despite
+the fact that older nodes with images present already have space that's taken up
+by user placeholder pods.
+
+So whenever a new node comes up, we label it and send the user placeholder pods there.
+This isn't the most elegant, generalized or correct solution, but it works for now.
+
+"""
+import logging
+import asyncio
+import aiohttp
+from kubernetes_asyncio import client, config
+import backoff
+
+# FIXME: Make these configurable
+namespace = 'datahub-prod'
+attractor_label = 'hub.jupyter.org/attract-placeholders'
+user_node_selector = 'hub.jupyter.org/node-purpose=user'
+
+
+# FIXME: More precise list of exceptions we want to retry on
+@backoff.on_exception(backoff.expo, exception=aiohttp.ClientError)
+async def label_newest_node(v1, namespace, user_node_selector, attractor_label):
+    # sort nodes in ascending order of creation time
+    nodes = sorted((await v1.list_node(label_selector=user_node_selector)).items, key=lambda n: n.metadata.creation_timestamp, reverse=True)
+
+    # Scheduler won't schedule any of our placeholder pods if our labeled node isn't
+    # marked as 'Ready', so we only operate on 'Ready' nodes
+    # FIXME: Label unready nodes, but wait for them to be ready before killing placeholders
+    ready_nodes = [
+        node for node in nodes
+        if any((c.type == 'Ready' and c.status == 'True' for c in node.status.conditions))
+    ]
+
+    # FIXME: Handle conflicts during patching operation
+    labeling_event = False
+    for i, node in enumerate(ready_nodes):
+        if i == 0:
+            # First node, ensure it has our attractor label
+            if attractor_label not in node.metadata.labels:
+                # Our youngest node doesn't have this label!
+                node.metadata.labels[attractor_label] = 'true'
+                await v1.patch_node(node.metadata.name, node)
+                logging.info(f'Adding label to {node.metadata.name}')
+                labeling_event = True
+        else:
+            if attractor_label in node.metadata.labels:
+                # Setting value to None removes the labels
+                node.metadata.labels[attractor_label] = None
+                await v1.patch_node(node.metadata.name, node)
+                logging.info(f'Removing label from {node.metadata.name}')
+                labeling_event = True
+
+    if labeling_event:
+        logging.info('Deleting placeholder pods to move them to newest node')
+        await asyncio.sleep(2)
+        await v1.delete_collection_namespaced_pod(namespace, label_selector='component=user-placeholder')
+    else:
+        logging.info(f'Newest node {ready_nodes[0].metadata.name} already has appropriate label, no action performed')
+
+
+async def main():
+    logging.basicConfig(format="%(asctime)s %(message)s", level=logging.INFO)
+    try:
+        config.load_incluster_config()
+        logging.debug('Acquired credentials from service account')
+    except:
+        await config.load_kube_config()
+        logging.debug('Acquired credentials from kubeconfig')
+
+    v1 = client.CoreV1Api()
+    while True:
+        await label_newest_node(v1, namespace, user_node_selector, attractor_label)
+        await asyncio.sleep(10)
+
+if __name__ == '__main__':
+    asyncio.get_event_loop().run_until_complete(main())

--- a/images/rebalancer/requirements.txt
+++ b/images/rebalancer/requirements.txt
@@ -1,0 +1,2 @@
+kubernetes_asyncio==10.0.0
+backoff==1.8.0

--- a/support/Chart.yaml
+++ b/support/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "1.0"
+appVersion: '1.0'
 description: Support chart for entire cluster
 name: support
-version: 0.1.0
+version: 0.1.0-b3e5b53

--- a/support/templates/rebalancer.yaml
+++ b/support/templates/rebalancer.yaml
@@ -1,0 +1,62 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: rebalancer
+  labels:
+    app: rebalancer
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: rebalancer
+  template:
+    metadata:
+      labels:
+        app: rebalancer
+    spec:
+      nodeSelector: {{ toJson .Values.rebalancer.nodeSelector }}
+      serviceAccountName: rebalancer
+      containers:
+        - name: rebalancer
+          image: {{ .Values.rebalancer.image.name }}:{{ .Values.rebalancer.image.tag }}
+          command:
+            - python3
+            - rebalancer.py
+          securityContext:
+            allowPrivilegeEscalation: false
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rebalancer
+  labels:
+    app: rebalancer
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rebalancer
+  labels:
+    app: rebalancer
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "watch", "list", "delete"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "watch", "list", "patch"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rebalancer
+  labels:
+    app: rebalancer
+subjects:
+  - kind: ServiceAccount
+    name: rebalancer
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: rebalancer
+  apiGroup: rbac.authorization.k8s.io

--- a/support/values.yaml
+++ b/support/values.yaml
@@ -1,8 +1,13 @@
+rebalancer:
+  image:
+    name: gcr.io/ucb-datahub-2018/jupyterhub-support-rebalancer
+    tag: '0.1.0-b3e5b53'
+
 prometheus:
   networkPolicy:
     enabled: true
   alertmanager:
-    enabled: False
+    enabled: false
   nodeExporter:
     tolerations:
       - effect: NoSchedule


### PR DESCRIPTION
When a cluster scales up, user pods are scheduled on to it immediately.
The user images aren't present on this node, and our images are so
big it takes about 10min for the images to land there. During this
time, all user pods scheduled on the new node fail, since the timeout
for new user spawns is 5min. The upshot is that whenever a new
node comes up, user spawns *fail* for about 10 minutes. This is
bad.

We have user placeholder pods that trigger scale-ups when the
cluster is about 90% full - this means new nodes come up before
the cluster is 100% full. However, because the new node is emptier
than the older nodes, user pods get scheduled on the new node -
even though it doesn't have the user images on it!

This adds a rebalancer script, that runs every 10s and does the
following:

1. Detects if a new node has been added
2. If so, it labels it a particular way that is set to attract the
   placeholder pods
3. It deletes all the placeholder pods, so they end up on the new node.

This frees up enough space in the older nodes, so user pods end up
there instead of in the newer, imageless node.

This is a stop-gap solution, and there could be many improvements
made to it - ultimately it will be superseeded by a Kubernetes
Feature directly. https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/1414
has more information & pointers.

We also automate the building of the hub & rebalancer image, so
that no longer needs to be done manually