### PR TITLE
Install curl in image building step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,9 +17,9 @@ orbs:
         steps:
           - checkout
           - run:
-              name: Install git
+              name: Install git & curl
               command: |
-                apt-get update && apt-get install --yes --no-install-recommends git
+                apt-get update && apt-get install --yes --no-install-recommends git curl
           - restore_cache:
               keys:
                 - v3.7-dependencies-{{ checksum "requirements.txt" }}
@@ -43,7 +43,7 @@ orbs:
               - run:
                 name: Install google cloud sdk
                 command: |
-                  wget -O - https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-226.0.0-linux-x86_64.tar.gz | tar -xzf -
+                  curl -sSL  https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-226.0.0-linux-x86_64.tar.gz | tar -xzf -
                   # Be careful with quote ordering here. ${PATH} must not be expanded
                   # Don't use ~ here - bash can interpret PATHs containing ~, but most other things can't.
                   # Always use full PATHs in PATH!

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,13 +41,13 @@ orbs:
               # Currently all our images live on google cloud, so we install gcloud sdk when pushing
               steps:
               - run:
-                name: Install google cloud sdk
-                command: |
-                  curl -sSL  https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-226.0.0-linux-x86_64.tar.gz | tar -xzf -
-                  # Be careful with quote ordering here. ${PATH} must not be expanded
-                  # Don't use ~ here - bash can interpret PATHs containing ~, but most other things can't.
-                  # Always use full PATHs in PATH!
-                  echo 'export PATH="${HOME}/repo/google-cloud-sdk/bin:${PATH}"' >> ${BASH_ENV}
+                  name: Install google cloud sdk
+                  command: |
+                    curl -sSL  https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-226.0.0-linux-x86_64.tar.gz | tar -xzf -
+                    # Be careful with quote ordering here. ${PATH} must not be expanded
+                    # Don't use ~ here - bash can interpret PATHs containing ~, but most other things can't.
+                    # Always use full PATHs in PATH!
+                    echo 'export PATH="${HOME}/repo/google-cloud-sdk/bin:${PATH}"' >> ${BASH_ENV}
 
           - setup_remote_docker
           - save_cache:


### PR DESCRIPTION
Turns out wget is actually *not* installed in the base
python image.

Reverts 11a7dc12890f7c931215c7cbd4970d7856d49a3c