### PR TITLE
Install git-crypt in image builder

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,9 +17,9 @@ orbs:
         steps:
           - checkout
           - run:
-              name: Install git & curl
+              name: Install git, git-crypt & curl
               command: |
-                apt-get update && apt-get install --yes --no-install-recommends git curl
+                apt-get update && apt-get install --yes --no-install-recommends git curl git-crypt
           - restore_cache:
               keys:
                 - v3.7-dependencies-{{ checksum "requirements.txt" }}


### PR DESCRIPTION
Required when we wanna push the image