### PR TITLE
Disable privilege escalation inside containers

### DIFF
--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -211,3 +211,10 @@ jupyterhub:
         # Allow unauthenticated prometheus requests
         # Otherwise our prometheus server can't get to these
         c.JupyterHub.authenticate_prometheus = False
+      06-no-setuid: |
+        c.KubeSpawner.extra_container_config = {
+          'securityContext': {
+            # Explicitly disallow setuid binaries from working inside the container
+            'allowPrivilegeEscalation': False
+          }
+        }


### PR DESCRIPTION
This pretty much turns off setuid binaries, which shouldn't be
present anyway.

Working on a 'JupyterHub security' post, so this seems
like a good start :)