### PR TITLE
Disable gofer grader temporarily

### DIFF
--- a/deployments/data8x/config/common.yaml
+++ b/deployments/data8x/config/common.yaml
@@ -8,10 +8,6 @@ nfsPVC:
     shareName: userhomes
 
 jupyterhub:
-  hub:
-    services:
-      gofer_nb:
-        url: http://35.239.20.122:10101
   auth:
     type: lti
     admin:


### PR DESCRIPTION
It is unreachable, causing the hub to stall a long time
before processing requests. This causes the hub to be entirely
down.

This can be reverted once gofer grader is back online