### PR TITLE
Switch to helm3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,9 +159,9 @@ jobs:
             rm ~/repo/key
 
       - run:
-          name: Install helm
+          name: Install helm3
           command: |
-            curl https://storage.googleapis.com/kubernetes-helm/helm-v2.12.3-linux-amd64.tar.gz | \
+            curl -L https://get.helm.sh/helm-v3.0.2-linux-amd64.tar.gz | \
               tar -xzf -
             mv linux-amd64/helm /usr/local/bin
             helm init --client-only

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "zero-to-jupyterhub-k8s"]
+	path = zero-to-jupyterhub-k8s
+	url = https://github.com/yuvipanda/zero-to-jupyterhub-k8s.git


### PR DESCRIPTION
Following instructions in https://helm.sh/blog/migrate-from-helm-v2-to-helm-v3/.
I ran the `helm3 2to3` commands manually on datahub and data8x clusters.