### PR TITLE
Deploy unmgerged z2jh changes to get new HTTPS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,6 +166,14 @@ jobs:
             mv linux-amd64/helm /usr/local/bin
             helm repo add jupyterhub https://jupyterhub.github.io/helm-chart/
             helm repo update
+      - run:
+          # HACK: We want HTTPS, but https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/1539
+          # is not merged yet
+          name: Update submodules & run chartpress
+          command: |
+            git submodule update --init
+            cd zero-to-jupyterhub-k8s
+            chartpress --skip-build
 
       - run:
           name: Post annotation to Grafana

--- a/hub/requirements.yaml
+++ b/hub/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
  - name: jupyterhub
    # REMEMBER TO CHANGE BASE IMAGE OF images/hub/ WHEN CHANGING THIS
-   version: v0.9-445a953
-   repository: https://jupyterhub.github.io/helm-chart
+   version: v0.0.1+3175.434f0d3
+   repository: file://../zero-to-jupyterhub-k8s/jupyterhub

--- a/images/hub/Dockerfile
+++ b/images/hub/Dockerfile
@@ -1,6 +1,6 @@
 # Should match the hub image used by version of chart in hub/requirements.yaml
 # If that changes, this should be changed too!
-FROM jupyterhub/k8s-hub:0.9-445a953
+FROM jupyterhub/k8s-hub:0.0.1_3164-a04b974
 
 USER root
 RUN apt update && apt install --yes curl python


### PR DESCRIPTION
This is madness, but I want to deploy https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/1539
before it is merged. So we add that in as a git submodule,
run chartpress without building images (since these images are
built already and pushed by me), and deploy from here.

Forgive me father for I have sinned.