### PR TITLE
Upgrade base distro of datahub image

### DIFF
--- a/deployments/datahub/images/default/Dockerfile
+++ b/deployments/datahub/images/default/Dockerfile
@@ -1,4 +1,5 @@
-FROM buildpack-deps:bionic-scm
+# Using a non LTS version here to get newer python
+FROM buildpack-deps:eoan-scm
 
 ENV APP_DIR /srv/app
 

--- a/deployments/datahub/images/default/nodesource.list
+++ b/deployments/datahub/images/default/nodesource.list
@@ -1,1 +1,1 @@
-deb https://deb.nodesource.com/node_8.x bionic main
+deb https://deb.nodesource.com/node_8.x eoan main


### PR DESCRIPTION
Easiest way for us to get a newer python. However, we should
look at alternate methods of obtaining python.