### PR TITLE
Move R installs to cran from github where possible

### DIFF
--- a/deployments/r/image/Dockerfile
+++ b/deployments/r/image/Dockerfile
@@ -64,8 +64,26 @@ RUN R --quiet -e "install.packages('IRkernel', quiet = TRUE)" && \
 
 # Install some R libraries that aren't in the base image
 COPY class-libs.R /tmp/class-libs.R
-COPY --chown=rstudio extras.d /tmp/extras.d
-RUN find /tmp/extras.d -type f | xargs -L1 Rscript
+
+RUN mkdir -p /tmp/extras.d
+
+COPY --chown=rstudio extras.d/example /tmp/extras.d
+RUN Rscript /tmp/extras.d/example
+
+COPY --chown=rstudio extras.d/2019-fall-stat-131a.r /tmp/extras.d/
+RUN Rscript /tmp/extras.d/2019-fall-stat-131a.r
+
+COPY --chown=rstudio extras.d/eep-1118.r /tmp/extras.d
+RUN Rscript /tmp/extras.d/eep-1118.r
+
+COPY --chown=rstudio extras.d/ias-c188.r /tmp/extras.d
+RUN Rscript /tmp/extras.d/ias-c188.r
+
+COPY --chown=rstudio extras.d/ph-142.r /tmp/extras.d
+RUN Rscript /tmp/extras.d/ph-142.r
+
+COPY --chown=rstudio extras.d/ph-w250fg.r /tmp/extras.d
+RUN Rscript /tmp/extras.d/ph-w250fg.r
 
 COPY --chown=rstudio:rstudio . ${REPO_DIR}
 

--- a/deployments/r/image/extras.d/eep-1118.r
+++ b/deployments/r/image/extras.d/eep-1118.r
@@ -4,8 +4,14 @@
 
 print("Installing packages for EEP 1118")
 
-print("Installing car...")
-devtools::install_github('cran/car', ref='3.0-2', upgrade_dependencies=FALSE, quiet=TRUE)
+source("/tmp/class-libs.R")
+
+class_name="EEP 1118"
+class_libs = c(
+    "car", "3.0-2"
+)
+
+class_libs_install_version(class_name, class_libs)
 
 print("Done installing packages for EEP 1118")
 

--- a/deployments/r/image/extras.d/ias-c188.r
+++ b/deployments/r/image/extras.d/ias-c188.r
@@ -1,22 +1,17 @@
 #!/usr/bin/env Rscript
 # From https://github.com/berkeley-dsep-infra/datahub/issues/814
-print("Installing packages for IA C188")
+#      https://github.com/berkeley-dsep-infra/datahub/issues/897
 
-# rdd requested in https://github.com/berkeley-dsep-infra/datahub/issues/897
-print("Installing rdd...")
-devtools::install_github('cran/rdd', ref='0.57', upgrade_dependencies=FALSE, quiet=TRUE)
+source("/tmp/class-libs.R")
 
-print("Installing stargazer...")
-devtools::install_github('cran/stargazer', ref='5.2.2', upgrade_dependencies=FALSE, quiet=TRUE)
+class_name = "IA C188"
+class_libs = c(
+    "rdd", "0.57",
+    "stargazer", "5.2.2",
+    "lm.beta", "1.5-1",
+    "multcomp", "1.4-8",
+    "lfe", "2.8-2"
+)
 
-print("Installing lm.beta...")
-devtools::install_github('cran/lm.beta', ref='1.5-1', upgrade_dependencies=FALSE, quiet=TRUE)
-
-print("Installing multcomp...")
-devtools::install_github('cran/multcomp', ref='1.4-8', upgrade_dependencies=FALSE, quiet=TRUE)
-
-print("Installing lfe...")
-devtools::install_github('cran/lfe', ref='2.8-2', upgrade_dependencies=FALSE, quiet=TRUE)
-
-print("Done installing packages for IA C188")
+class_libs_install_version(class_name, class_libs)
 

--- a/deployments/r/image/extras.d/ph-142.r
+++ b/deployments/r/image/extras.d/ph-142.r
@@ -15,12 +15,15 @@ class_libs = c(
     "infer", "0.4.0.1",
     "janitor", "1.2.0",
     "latex2exp", "0.4.0",
-    "cowplot", "1.0.0",
     "measurements", "1.3.0",
     "dagitty", "0.2-2"
 )
 
 class_libs_install_version(class_name, class_libs)
+
+# not found in CRAN
+print("Installing patchwork...")
+devtools::install_github('cran/cowplot', ref='1.0.0', upgrade_dependencies=FALSE, quiet=TRUE)
 
 print("Installing patchwork...")
 devtools::install_github('thomasp85/patchwork', ref='36b4918', upgrade_dependencies=FALSE, quiet=TRUE)

--- a/deployments/r/image/extras.d/ph-142.r
+++ b/deployments/r/image/extras.d/ph-142.r
@@ -2,41 +2,28 @@
 # From https://github.com/berkeley-dsep-infra/datahub/issues/881
 print("Installing packages for PH142")
 
-print("Installing fGarch...")
-devtools::install_github('cran/fGarch', ref='3042.83.1', upgrade_dependencies=FALSE, quiet=TRUE)
+source("/tmp/class-libs.R")
 
-print("Installing SASxport...")
-devtools::install_github('cran/SASxport', ref='1.6.0', upgrade_dependencies=FALSE, quiet=TRUE)
+class_name = "PH142"
 
-print("Installing googlesheets...")
-devtools::install_github('cran/googlesheets', ref='0.3.0', upgrade_dependencies=FALSE, quiet=TRUE)
+class_libs = c(
+    "fGarch", "3042.83.1",
+    "SASxport", "1.6.0",
+    "googlesheets", "0.3.0",
+    "googledrive", "0.1.3",
+    "ggrepel", "0.8.1",
+    "infer", "0.4.0.1",
+    "janitor", "1.2.0",
+    "latex2exp", "0.4.0",
+    "cowplot", "1.0.0",
+    "measurements", "1.3.0",
+    "dagitty", "0.2-2"
+)
 
-print("Installing googledrive...")
-devtools::install_github('cran/googledrive', ref='0.1.3', upgrade_dependencies=FALSE, quiet=TRUE)
+class_libs_install_version(class_name, class_libs)
 
 print("Installing patchwork...")
 devtools::install_github('thomasp85/patchwork', ref='36b4918', upgrade_dependencies=FALSE, quiet=TRUE)
-
-print("Installing ggrepel...")
-devtools::install_github('cran/ggrepel', ref='0.8.1', upgrade_dependencies=FALSE, quiet=TRUE)
-
-print("Installing infer...")
-devtools::install_github('cran/infer', ref='0.4.0.1', upgrade_dependencies=FALSE, quiet=TRUE)
-
-print("Installing janitor...")
-devtools::install_github('cran/janitor', ref='1.2.0', upgrade_dependencies=FALSE, quiet=TRUE)
-
-print("Installing latex2exp...")
-devtools::install_github('cran/latex2exp', ref='0.4.0', upgrade_dependencies=FALSE, quiet=TRUE)
-
-print("Installing cowplot...")
-devtools::install_github('cran/cowplot', ref='1.0.0', upgrade_dependencies=FALSE, quiet=TRUE)
-
-print("Installing measurements...")
-devtools::install_github('cran/measurements', ref='1.3.0', upgrade_dependencies=FALSE, quiet=TRUE)
-
-print("Installing dagitty...")
-devtools::install_github('cran/dagitty', ref='0.2-2', upgrade_dependencies=FALSE, quiet=TRUE)
 
 print("Installing tigris...")
 devtools::install_github('walkerke/tigris', ref='78d1e44ccc1f561342078c0e79d0415fa4396389', upgrade_dependencies=FALSE, quiet=TRUE)

--- a/deployments/r/image/extras.d/ph-w250fg.r
+++ b/deployments/r/image/extras.d/ph-w250fg.r
@@ -2,32 +2,23 @@
 # From https://github.com/berkeley-dsep-infra/datahub/issues/881
 print("Installing packages for PHW250F+G")
 
-print("Installing here...")
-devtools::install_github('cran/here', ref='0.1', upgrade_dependencies=FALSE, quiet=TRUE)
-
-print("Installing rlist...")
-devtools::install_github('cran/rlist', ref='0.4.6.1', upgrade_dependencies=FALSE, quiet=TRUE)
-
-print("Installing jsonlite...")
-devtools::install_github('cran/jsonlite', ref='1.6', upgrade_dependencies=FALSE, quiet=TRUE)
-
-print("Installing checkr...")
-devtools::install_github('cran/checkr', ref='0.5.0', upgrade_dependencies=FALSE, quiet=TRUE)
+source("/tmp/class-libs.R")
 
 # dplyr requires 0.2.1...cran only has 0.2.0
 print("Installing assertthat...")
 devtools::install_github('hadley/assertthat', ref='v0.2.1', upgrade_dependencies=FALSE, quiet=TRUE)
 
-print("Installing dplyr...")
-devtools::install_github('cran/dplyr', ref='0.8.1', upgrade_dependencies=FALSE, quiet=TRUE)
+class_name = "PHW250F+G"
 
-print("Installing ggplot2...")
-devtools::install_github('cran/ggplot2', ref='3.1.0', upgrade_dependencies=FALSE, quiet=TRUE)
+class_libs = c(
+    "here", "0.1",
+    "rlist", "0.4.6.1",
+    "jsonlite", "1.6",
+    "checkr", "0.5.0",
+    "dplyr", "0.8.1",
+    "ggplot2", "3.1.0",
+    "tidyr", "0.8.3",
+    "reticulate", "1.13"
+)
 
-print("Installing tidyr...")
-devtools::install_github('cran/tidyr', ref='0.8.3', upgrade_dependencies=FALSE, quiet=TRUE)
-
-print("Installing reticulate...")
-devtools::install_github('cran/reticulate', ref='1.13', upgrade_dependencies=FALSE, quiet=TRUE)
-
-print("Done installing packages for PHW250F+G")
+class_libs_install_version(class_name, class_libs)

--- a/deployments/r/image/extras.d/ph-w250fg.r
+++ b/deployments/r/image/extras.d/ph-w250fg.r
@@ -17,7 +17,7 @@ class_libs = c(
     "checkr", "0.5.0",
     "dplyr", "0.8.1",
     "ggplot2", "3.1.0",
-    "tidyr", "0.8.3",
+    "tidyr", "0.8.3"
 )
 
 # 1.13 isn't found in cran?

--- a/deployments/r/image/extras.d/ph-w250fg.r
+++ b/deployments/r/image/extras.d/ph-w250fg.r
@@ -18,7 +18,10 @@ class_libs = c(
     "dplyr", "0.8.1",
     "ggplot2", "3.1.0",
     "tidyr", "0.8.3",
-    "reticulate", "1.13"
 )
+
+# 1.13 isn't found in cran?
+print("Installing reticulate...")
+devtools::install_github('cran/reticulate', ref='1.13', upgrade_dependencies=FALSE, quiet=TRUE)
 
 class_libs_install_version(class_name, class_libs)


### PR DESCRIPTION
We keep running into GitHub rate limits when installing
R packages. This should have the same effects