### PR TITLE
Increase start timeout for user pods

### DIFF
--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -52,6 +52,7 @@ jupyterhub:
     networkPolicy:
       enabled: true
   singleuser:
+    startTimeout: 600 # 10 mins, because sometimes we have too many new nodes coming up together
     defaultUrl: /tree
     networkPolicy:
       # In clusters with NetworkPolicy enabled, do not


### PR DESCRIPTION
We went from 12 to 19 nodes this morning, and several
users had timeout issues because of the large number of new
nodes coming up. This is a bandaid