### PR TITLE
Don't use z2jh from a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "zero-to-jupyterhub-k8s"]
-	path = zero-to-jupyterhub-k8s
-	url = https://github.com/yuvipanda/zero-to-jupyterhub-k8s.git

--- a/hub/requirements.yaml
+++ b/hub/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
  - name: jupyterhub
    # REMEMBER TO CHANGE BASE IMAGE OF images/hub/ WHEN CHANGING THIS
-   version: v0.0.1-n3180.h9f01fda
-   repository: file://../zero-to-jupyterhub-k8s/jupyterhub
+   version: 0.9.0-beta.3.n007.hc58048a
+   repository: https://jupyterhub.github.io/helm-chart/

--- a/images/hub/Dockerfile
+++ b/images/hub/Dockerfile
@@ -1,6 +1,6 @@
 # Should match the hub image used by version of chart in hub/requirements.yaml
 # If that changes, this should be changed too!
-FROM jupyterhub/k8s-hub:0.0.1_3164-a04b974
+FROM jupyterhub/k8s-hub:0.9.0-beta.3.n000.h9e1a7f9
 
 USER root
 RUN apt update && apt install --yes curl python


### PR DESCRIPTION
We were waiting for https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/1539
to be merged. It has been merged!