### PR TITLE
Lower guarantee for data100

### DIFF
--- a/deployments/data100/config/common.yaml
+++ b/deployments/data100/config/common.yaml
@@ -77,7 +77,7 @@ jupyterhub:
         pvcName: home-nfs
         subPath: "{username}"
     memory:
-      guarantee: 512G
+      guarantee: 768M
       limit: 2G
     image:
       name: gcr.io/ucb-datahub-2018/data100-user-image

--- a/deployments/data100/config/common.yaml
+++ b/deployments/data100/config/common.yaml
@@ -77,7 +77,7 @@ jupyterhub:
         pvcName: home-nfs
         subPath: "{username}"
     memory:
-      guarantee: 1G
+      guarantee: 512G
       limit: 2G
     image:
       name: gcr.io/ucb-datahub-2018/data100-user-image


### PR DESCRIPTION
Based on memory usage info
(http://grafana.datahub.berkeley.edu/d/naRCw05Wz/cluster-health?orgId=1&refresh=1m&from=now-24h&to=now&fullscreen&panelId=8)
we could save a good chunk of cost by overprovisioning a little more.

With this, we'd require a large number of users on the same node
to go over this memory guarantee at the same time for *some* user pods
to die. We are further protected by the fact that we set memory limits
for all our user pods - 1G for datahub, 2G for data100. This makes it
harder for this condition to occur.

With the data, we see this hasn't ever happened. We can bump this
back up if needed.