### PR TITLE
Change git source repository for gitpuller for STAT 89A hub

### DIFF
--- a/deployments/stat89a/config/common.yaml
+++ b/deployments/stat89a/config/common.yaml
@@ -28,4 +28,4 @@ jupyterhub:
     lifecycleHooks:
       postStart:
         exec:
-          command: ["gitpuller", "https://github.com/STAT-89A/spring_2020", "master", "STAT\ 89A\ 2020"]
+          command: ["gitpuller", "https://gitlab.com/stat-89a/spring-2020/spring_2020.git", "master", "STAT\ 89A\ 2020"]


### PR DESCRIPTION
Reason in title.

Want to pull/merge from this remote repository:
https://gitlab.com/stat-89a/spring-2020/spring_2020

and no longer from this one:
https://github.com/STAT-89A/spring_2020