### PR TITLE
Lower guarantee for data100 to 512

### DIFF
--- a/deployments/data100/config/common.yaml
+++ b/deployments/data100/config/common.yaml
@@ -88,7 +88,7 @@ jupyterhub:
           subPath: _shared
           readOnly: true
     memory:
-      guarantee: 768M
+      guarantee: 512M
       limit: 2G
     image:
       name: gcr.io/ucb-datahub-2018/data100-user-image


### PR DESCRIPTION
Followup to https://github.com/berkeley-dsep-infra/datahub/pull/1279
as no issues were reported