### PR TITLE
Move *just* data100 to a new 'beta' pool

### DIFF
--- a/deployments/data100/config/common.yaml
+++ b/deployments/data100/config/common.yaml
@@ -94,6 +94,8 @@ jupyterhub:
         - jegonzal
 
   singleuser:
+    nodeSelector:
+      hub.jupyter.org/pool-name: beta-pool
     initContainers:
       - name: volume-mount-hack
         image: busybox

--- a/deployments/stat89a/config/common.yaml
+++ b/deployments/stat89a/config/common.yaml
@@ -17,6 +17,8 @@ jupyterhub:
           - wqixuan
 
   singleuser:
+    nodeSelector:
+      hub.jupyter.org/node-purpose: user
     memory:
       guarantee: 512M
       limit: 1G


### PR DESCRIPTION
The data100 image is about 10G. When a new node spawns, it
must pull in this image, in addition to the datahub image (which
is already about 9G) before stuff can realistically start. This
has lead to extremely long node spin up times.

We're going to split data100 into its own node pool, with its
own autoscaling behavior. This should help reduce the total
size of images on each node, and parallelize the scale-up behavior

stat89a did not have a specific node selector, so we add one
to make it use the default node pool