### PR TITLE
Put datahub in its own pool

### DIFF
--- a/deployments/datahub/config/common.yaml
+++ b/deployments/datahub/config/common.yaml
@@ -162,7 +162,7 @@ jupyterhub:
           - tongshen
   singleuser:
     nodeSelector:
-      hub.jupyter.org/node-purpose: user
+      hub.jupyter.org/pool-name: alpha-pool
     storage:
       type: none
     memory:


### PR DESCRIPTION
Follow up to https://github.com/berkeley-dsep-infra/datahub/pull/1321,
we want to put all the hubs that use the datahub image into the alpha
pool. This way we won't have multiple large images on all the nodes