### PR TITLE
Put workshop hub's users on datahub's pool

### DIFF
--- a/deployments/workshop/config/common.yaml
+++ b/deployments/workshop/config/common.yaml
@@ -38,6 +38,9 @@ jupyterhub:
           - rylo
           - yuvipanda
   singleuser:
+    nodeSelector:
+      # Co-locate with datahub, since workshop shares its image
+      hub.jupyter.org/pool-name: alpha-pool
     image:
       # Matches datahub image
       name: gcr.io/ucb-datahub-2018/primary-user-image


### PR DESCRIPTION
We don't want the big datahub image to be present on any
nodes it doesn't need to be in. If we don't limit this, the
hook pre-puller will pull this image in all nodes - we do
not want that.