### PR TITLE
Add user-placeholders for data100 too

### DIFF
--- a/deployments/data100/config/prod.yaml
+++ b/deployments/data100/config/prod.yaml
@@ -8,3 +8,8 @@ jupyterhub:
       pvc:
         # This also holds logs
         storage: 40Gi
+
+  scheduling:
+    userPlaceholder:
+      enabled: true
+      replicas: 160


### PR DESCRIPTION
Since data100 and datahub are now on different nodegroups
that scale independently, it'll be useful to have two different
placeholder pods. This might actually make them behave in the ways
we want them to!