### PR TITLE
Add about 1 node of headroom to prob1400

### DIFF
--- a/deployments/prob140/config/prod.yaml
+++ b/deployments/prob140/config/prod.yaml
@@ -1,4 +1,9 @@
 jupyterhub:
+  scheduling:
+    userPlaceholder:
+      enabled: true
+      # About one node of headroom
+      replicas: 60
   proxy:
     service:
       loadBalancerIP: 35.184.101.216


### PR DESCRIPTION
There's no headroom on any hub in the default nodepool,
so we explicitly add one for prob140. It's unclear how this
affects other hubs - but prob140 is the biggest hub left here