### PR TITLE
Revert "Delete lifecycle hook; it was a bad idea"

### DIFF
--- a/deployments/stat89a/config/common.yaml
+++ b/deployments/stat89a/config/common.yaml
@@ -27,3 +27,7 @@ jupyterhub:
     storage:
       type: hostPath
     defaultUrl: "/lab"
+    lifecycleHooks:
+      postStart:
+        exec:
+          command: ["gitpuller", "https://gitlab.com/stat-89a/spring-2020/spring_2020.git", "master", "STAT\ 89A\ 2020"]


### PR DESCRIPTION
Reverts berkeley-dsep-infra/datahub#1341

It was a bad idea, and although deleting it fixed the problem for my server, at this point we are too deep into the semester for reversing it to not create more work than it prevents