### PR TITLE
Revert "Add nbforms for Data 8X feedback"

### DIFF
--- a/deployments/data8x/image/requirements.txt
+++ b/deployments/data8x/image/requirements.txt
@@ -4,7 +4,6 @@ matplotlib==3.0.2
 pandas==0.23.4
 scipy==1.2.0
 nbresuse==0.3.2
-nbforms==0.5.1
 # For grading
 gofer-grader==1.1.0
 gofer-submit==0.3


### PR DESCRIPTION
Reverts berkeley-dsep-infra/datahub#1373

Removing nbforms to merge nb2pdf update to prod. Not ready to deploy nbforms into 8x prod yet, waiting for patch to Gofer-Grader