### PR TITLE
Reduce number of placeholder pods

### DIFF
--- a/deployments/data100/config/prod.yaml
+++ b/deployments/data100/config/prod.yaml
@@ -12,4 +12,4 @@ jupyterhub:
   scheduling:
     userPlaceholder:
       enabled: true
-      replicas: 160
+      replicas: 80

--- a/deployments/datahub/config/prod.yaml
+++ b/deployments/datahub/config/prod.yaml
@@ -38,4 +38,4 @@ jupyterhub:
   scheduling:
     userPlaceholder:
       enabled: true
-      replicas: 160
+      replicas: 80

--- a/deployments/prob140/config/prod.yaml
+++ b/deployments/prob140/config/prod.yaml
@@ -2,8 +2,7 @@ jupyterhub:
   scheduling:
     userPlaceholder:
       enabled: true
-      # About one node of headroom
-      replicas: 60
+      replicas: 20
   proxy:
     service:
       loadBalancerIP: 35.184.101.216

--- a/deployments/r/config/prod.yaml
+++ b/deployments/r/config/prod.yaml
@@ -13,4 +13,4 @@ jupyterhub:
   scheduling:
     userPlaceholder:
       enabled: true
-      replicas: 60
+      replicas: 20


### PR DESCRIPTION
Placeholder pods had been overprovisioned to make sure students
do not have timeouts due to node spin up time. However, with
separate nodepools, the spin up time has reduced (due to reduced
number of images on each node) and autoscaling behavior has improved
(since each node group autoscales independently). Grafana seems
to bear this out, so these placeholder pods can be reduced to
save cost.

Ref #52
