### PR TITLE
Move hubs to gamma pool

### DIFF
--- a/deployments/data102/config/common.yaml
+++ b/deployments/data102/config/common.yaml
@@ -32,7 +32,7 @@ jupyterhub:
 
   singleuser:
     nodeSelector:
-      hub.jupyter.org/node-purpose: user
+      hub.jupyter.org/pool-name: gamma-pool
     initContainers:
       - name: volume-mount-hack
         image: busybox

--- a/deployments/desktop-test/config/common.yaml
+++ b/deployments/desktop-test/config/common.yaml
@@ -21,7 +21,7 @@ jupyterhub:
   singleuser:
     defaultUrl: /desktop
     nodeSelector:
-      hub.jupyter.org/node-purpose: user
+      hub.jupyter.org/pool-name: gamma-pool
     initContainers:
       - name: volume-mount-hack
         image: busybox

--- a/deployments/julia/config/common.yaml
+++ b/deployments/julia/config/common.yaml
@@ -30,7 +30,7 @@ jupyterhub:
 
   singleuser:
     nodeSelector:
-      hub.jupyter.org/node-purpose: user
+      hub.jupyter.org/pool-name: gamma-pool
     initContainers:
       - name: volume-mount-hack
         image: busybox

--- a/deployments/prob140/config/common.yaml
+++ b/deployments/prob140/config/common.yaml
@@ -38,7 +38,7 @@ jupyterhub:
 
   singleuser:
     nodeSelector:
-      hub.jupyter.org/node-purpose: user
+      hub.jupyter.org/pool-name: gamma-pool
     initContainers:
       - name: volume-mount-hack
         image: busybox

--- a/deployments/r/config/common.yaml
+++ b/deployments/r/config/common.yaml
@@ -70,7 +70,7 @@ jupyterhub:
 
   singleuser:
     nodeSelector:
-      hub.jupyter.org/node-purpose: user
+      hub.jupyter.org/pool-name: gamma-pool
     initContainers:
       - name: volume-mount-hack
         image: busybox

--- a/deployments/stat89a/config/common.yaml
+++ b/deployments/stat89a/config/common.yaml
@@ -18,7 +18,7 @@ jupyterhub:
 
   singleuser:
     nodeSelector:
-      hub.jupyter.org/node-purpose: user
+      hub.jupyter.org/pool-name: gamma-pool
     memory:
       guarantee: 512M
       limit: 1G


### PR DESCRIPTION
gamma-pool is e2-highmem-8 instances, instead of n1-highmem-8.
These do not qualify for sustained use, so are generally more
expensive. However, they *do* qualify for committed use, and
they are much cheaper there - about 32% cheaper than what we
are doing now.

This moves the following hubs to a new pool I created, with
e2-highmem-8:

- data102
- desktop-test
- julia
- prob140
- r
- stat89a

Ref #1354