### PR TITLE
Put workshop users only on alpha-pool

### DIFF
--- a/deployments/workshop/config/common.yaml
+++ b/deployments/workshop/config/common.yaml
@@ -44,8 +44,6 @@ jupyterhub:
     image:
       # Matches datahub image
       name: gcr.io/ucb-datahub-2018/primary-user-image
-    nodeSelector:
-      hub.jupyter.org/node-purpose: user
     initContainers:
       - name: volume-mount-hack
         image: busybox


### PR DESCRIPTION
workshop hub uses same image as datahub, and we do not want
the datahub image on other pool's nodes. This config actually
put the workshop hub in the default pool (now gamma pool),
thus bringing the datahub image there. We remove it, thus
making default pool (gamma pool) node spinups faster.