### PR TITLE
Put stat89a core pods on core nodes

### DIFF
--- a/deployments/stat89a/config/common.yaml
+++ b/deployments/stat89a/config/common.yaml
@@ -1,4 +1,14 @@
 jupyterhub:
+  scheduling:
+    userScheduler:
+      nodeSelector:
+        hub.jupyter.org/node-purpose: core
+  proxy:
+    nodeSelector:
+      hub.jupyter.org/node-purpose: core
+  hub:
+    nodeSelector:
+      hub.jupyter.org/node-purpose: core
   auth:
     type: google
     admin:


### PR DESCRIPTION
They were already on the core nodes thanks to our
taints, but this makes it much more explicit