### PR TITLE
Provision more headroom for r and prob140 hub

### DIFF
--- a/deployments/prob140/config/prod.yaml
+++ b/deployments/prob140/config/prod.yaml
@@ -2,7 +2,7 @@ jupyterhub:
   scheduling:
     userPlaceholder:
       enabled: true
-      replicas: 20
+      replicas: 50
   proxy:
     service:
       loadBalancerIP: 35.184.101.216

--- a/deployments/r/config/prod.yaml
+++ b/deployments/r/config/prod.yaml
@@ -13,4 +13,4 @@ jupyterhub:
   scheduling:
     userPlaceholder:
       enabled: true
-      replicas: 20
+      replicas: 50


### PR DESCRIPTION
New e2 nodes are being used for these hubs now, and one had
a networkplugin failure just now. Bringing up a brand new
node takes 10 minutes, and that is precious time. With a
larger number of placeholders, the autoscaler will provision
new nodes earlier. This isolates issues of e2 nodes' network
plugins not starting up properly from general issues of
too much rush.

Ref #1354