### PR TITLE
Disable nfsMounter for data102

### DIFF
--- a/deployments/data102/config/common.yaml
+++ b/deployments/data102/config/common.yaml
@@ -1,3 +1,5 @@
+nfsMounter:
+  enabled: false
 nfsPVC:
   enabled: true
   nfs:


### PR DESCRIPTION
It was already using nfsPVC, the nfsMounter was just not
disabled explicitly

stat89a and datahub are left.

Ref #1370 