### PR TITLE
Run postgres as a sidecar on data100 hub

### DIFF
--- a/deployments/data100/config/common.yaml
+++ b/deployments/data100/config/common.yaml
@@ -94,6 +94,19 @@ jupyterhub:
         - jegonzal
 
   singleuser:
+    extraContainers:
+      - name: postgres
+        image: postgres:12.2
+        resources:
+          limits:
+            memory: 512Mi
+          requests:
+            memory: 128Mi
+        env:
+        - name: POSTGRES_HOST_AUTH_METHOD
+          value: "trust"
+        - name: POSTGRES_USER
+          value: "jovyan"
     nodeSelector:
       hub.jupyter.org/pool-name: beta-pool
     initContainers:


### PR DESCRIPTION
There is a running conversation with Joey, the professor
who is currently teaching data100, about providing
postgres' servers for data100 students. Due to the
multi-tenancy, flexibility and maintenance requirements,
I decided that the easiest thing to do is to run a postgres
server as a sidecar for each user.

We use the upstream postgres image, which is solid but does
not have a lot of extensions we want. We can add that later.
We also currently do not offer any persistent storage -
that requires a small estimation of cost, and we can do
that later too.

Once this is merged, you can do:

psql -h localhost

on your terminal, and get into postgres!

Your data will be lost at server stop, but that's ok for now.