### PR TITLE
Make postgres for data100 more robust

### DIFF
--- a/deployments/data100/config/common.yaml
+++ b/deployments/data100/config/common.yaml
@@ -93,6 +93,12 @@ jupyterhub:
         - adhikari
         - jegonzal
 
+  prePuller:
+    extraImages:
+      postgres:
+        name: postgres
+        tag: 122
+        policy: IfNotPresent
   singleuser:
     extraContainers:
       - name: postgres

--- a/deployments/data100/config/common.yaml
+++ b/deployments/data100/config/common.yaml
@@ -64,7 +64,7 @@ jupyterhub:
         - manana.hakobyan
         - andysheu
         - allenshen5
-        
+
         # tutors
         - wesley1016
         - ischmidt20
@@ -99,9 +99,9 @@ jupyterhub:
         image: postgres:12.2
         resources:
           limits:
+            # Best effort only. No more than 1 CPU
             memory: 512Mi
-          requests:
-            memory: 128Mi
+            cpu: 1.0
         env:
         - name: POSTGRES_HOST_AUTH_METHOD
           value: "trust"


### PR DESCRIPTION
- pre-pull postgres image on all nodes, for faster startup
- Reduce resource requests for postgres containers, so the
  pods are besteffort - we don't want to cause problems for
  user notebook resources because of postgres.