### PR TITLE
Explicitly set requests on postgres sidecar

### DIFF
--- a/deployments/data100/config/common.yaml
+++ b/deployments/data100/config/common.yaml
@@ -93,26 +93,26 @@ jupyterhub:
         - adhikari
         - jegonzal
 
-#  prePuller:
-#    extraImages:
-#      postgres:
-#        name: postgres
-#        tag: 12.2
-#        policy: IfNotPresent
+  prePuller:
+    extraImages:
+      postgres:
+        name: postgres
+        tag: 12.2
+        policy: IfNotPresent
   singleuser:
-#    extraContainers:
-#      - name: postgres
-#        image: postgres:12.2
-#        resources:
-#          limits:
-#            # Best effort only. No more than 1 CPU
-#            memory: 512Mi
-#            cpu: 1.0
-#        env:
-#        - name: POSTGRES_HOST_AUTH_METHOD
-#          value: "trust"
-#        - name: POSTGRES_USER
-#          value: "jovyan"
+    extraContainers:
+      - name: postgres
+        image: postgres:12.2
+        resources:
+          limits:
+            # Best effort only. No more than 1 CPU
+            memory: 512Mi
+            cpu: 1.0
+        env:
+        - name: POSTGRES_HOST_AUTH_METHOD
+          value: "trust"
+        - name: POSTGRES_USER
+          value: "jovyan"
     nodeSelector:
       hub.jupyter.org/pool-name: beta-pool
     initContainers:

--- a/deployments/data100/config/common.yaml
+++ b/deployments/data100/config/common.yaml
@@ -108,6 +108,10 @@ jupyterhub:
             # Best effort only. No more than 1 CPU
             memory: 512Mi
             cpu: 1.0
+          requests:
+            # If we don't set requests, k8s sets requests == limits!
+            memory: 64Mi
+            cpu: 0.01
         env:
         - name: POSTGRES_HOST_AUTH_METHOD
           value: "trust"


### PR DESCRIPTION
If you don't set requests, kubernetes sets requests == limits.

This causes resource exhaustion