### PR TITLE
Mount homedir in postgres container as well

### DIFF
--- a/deployments/data100/config/common.yaml
+++ b/deployments/data100/config/common.yaml
@@ -117,6 +117,14 @@ jupyterhub:
           value: "trust"
         - name: POSTGRES_USER
           value: "jovyan"
+        volumeMounts:
+        - name: home
+          mountPath: /home/jovyan
+          subPath: "{username}"
+        - name: home
+          mountPath: /home/jovyan/shared
+          subPath: _shared
+          readOnly: true
     nodeSelector:
       hub.jupyter.org/pool-name: beta-pool
     initContainers:


### PR DESCRIPTION
This lets users do things like
`copy allstarfull from '/home/jovyan/baseballdatabank-master/core/AllstarFull.csv';
without running into issues about different filesystems