### PR TITLE
Use newer version of repo2docker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,8 +33,8 @@ orbs:
                 python3 -m venv venv
                 source venv/bin/activate
                 pip install --upgrade -r requirements.txt
-                # Install latest repo2docker to https://github.com/jupyter/repo2docker/pull/657
-                pip install --upgrade git+https://github.com/jupyter/repo2docker@e976627c1e238cf654ad178456b1bf81db7aac36
+                # Install latest repo2docker to get https://github.com/jupyter/repo2docker/pull/859
+                pip install --upgrade git+https://github.com/jupyter/repo2docker@bbc3ee02c0755b15ea456f9ae18dd76b904568e7
                 echo 'export PATH="${HOME}/repo/venv/bin:$PATH"' >> ${BASH_ENV}
 
           - unless:
@@ -115,8 +115,8 @@ jobs:
             python3 -m venv venv
             source venv/bin/activate
             pip install --upgrade -r requirements.txt
-            # Install latest repo2docker to https://github.com/jupyter/repo2docker/pull/657
-            pip install --upgrade git+https://github.com/jupyter/repo2docker@e976627c1e238cf654ad178456b1bf81db7aac36
+            # Install latest repo2docker to get https://github.com/jupyter/repo2docker/pull/859
+            pip install --upgrade git+https://github.com/jupyter/repo2docker@bbc3ee02c0755b15ea456f9ae18dd76b904568e7
 
             # Can be removed once https://github.com/docker/docker-py/issues/2225 is merged and released
             pip install --upgrade git+https://github.com/docker/docker-py.git@b6f6e7270ef1acfe7398b99b575d22d0d37ae8bf
@@ -463,4 +463,3 @@ workflows:
               only:
                 - staging
                 - prod
-                

--- a/deployments/desktop-test/image/environment.yml
+++ b/deployments/desktop-test/image/environment.yml
@@ -3,5 +3,5 @@ channels:
 dependencies:
   - websockify
   - pip:
-    - https://github.com/jupyterhub/jupyter-server-proxy/archive/0e67e1afd0bab1342443f13bd147a2f8c682e9e0.zip
+    - jupyter-server-proxy
     - jupyter-desktop-server==0.1.2


### PR DESCRIPTION
This uses miniforge instead of miniconda to get python.

See https://github.com/berkeley-dsep-infra/datahub/issues/1456
for rationale.

We make a small change in desktop-test to trigger a
rebuild, so it can be rebuilt to use miniforge

Ref #1456