### PR TITLE
Add Python language support to data100 postgresql

### DIFF
--- a/chartpress.yaml
+++ b/chartpress.yaml
@@ -9,3 +9,8 @@ charts:
     images:
       hub:
         valuesPath: jupyterhub.hub.image
+      postgres:
+      # FIXME: This should be used *only with the common.yaml of data100hub
+      # There's no way to tell Chartpress to do that now, since it overwrites values.yaml
+      # So we need to manually set this, after running chartpress --push
+        valuesPath: {}

--- a/deployments/data100/config/common.yaml
+++ b/deployments/data100/config/common.yaml
@@ -102,7 +102,7 @@ jupyterhub:
   singleuser:
     extraContainers:
       - name: postgres
-        image: postgres:12.2
+        image: gcr.io/ucb-datahub-2018/jupyterhub-postgres:0.0.1-n2510.hd28e63b
         resources:
           limits:
             # Best effort only. No more than 1 CPU

--- a/docs/howto/rebuild-hub-image.rst
+++ b/docs/howto/rebuild-hub-image.rst
@@ -24,3 +24,29 @@ version.
    name and tag are comitted.
 
 #. Proceed to deployment as normal.
+
+=================================
+Rebuild the custom postgres image
+=================================
+
+For data100, we provide a postgresql server per user. We want the
+`python extension <https://www.postgresql.org/docs/current/plpython.html>`_
+installed. So we inherit from the `upstream postgresql docker image
+<https://hub.docker.com/_/postgres>`_, and add the appropriate package.
+
+This image is in ``images/postgres``. If you update it, you need to
+rebuild and push it.
+
+#. Modify the image in ``images/postgres`` and make a git commit.
+
+#. Run ``chartpress --push``. This will build and push the image,
+   *but not put anything in YAML*. There is no place we can put thi
+   in ``values.yaml``, since this is only used for data100.
+
+#. Notice the image name + tag from the ``chartpress --push`` command,
+   and put it in the appropriate place (under ``extraContainers``) in
+   ``data100/config/common.yaml``.
+
+#. Make a commit with the new tag in ``data100/config/common.yaml``.
+
+#. Proceed to deploy as normal.

--- a/images/postgres/Dockerfile
+++ b/images/postgres/Dockerfile
@@ -1,0 +1,8 @@
+FROM postgres:12.2
+
+# Install python3 language extension from https://wiki.postgresql.org/wiki/Apt
+RUN apt-get update && \
+    apt-get install --yes \
+        postgresql-plpython3-${PG_MAJOR} && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Adds [python3 postgresql support](https://www.postgresql.org/docs/current/plpython.html)
to the postgres image used by data100.