### PR TITLE
Revert "Use hub image with 1.1.0."

### DIFF
--- a/hub/requirements.yaml
+++ b/hub/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
  - name: jupyterhub
    # REMEMBER TO CHANGE BASE IMAGE OF images/hub/ WHEN CHANGING THIS
-   version: 0.9.0-n033.h8211ad2
+   version: 0.9.0-beta.3.n007.hc58048a
    repository: https://jupyterhub.github.io/helm-chart/

--- a/images/hub/Dockerfile
+++ b/images/hub/Dockerfile
@@ -1,6 +1,6 @@
 # Should match the hub image used by version of chart in hub/requirements.yaml
 # If that changes, this should be changed too!
-FROM jupyterhub/k8s-hub:0.9.0-n033.h8211ad2
+FROM jupyterhub/k8s-hub:0.9.0-beta.3.n000.h9e1a7f9
 
 USER root
 RUN apt update && apt install --yes curl python
@@ -19,10 +19,13 @@ RUN python3 -m pip install --no-cache /srv/sparklyspawner
 COPY canvasauthenticator /srv/canvasauthenticator
 RUN python3 -m pip install --no-cache /srv/canvasauthenticator
 
+# Install JupyterHub from master!
+# This is scary-ish, but we need JupyterHub master for the analytics / user-redirect work
 # npm's dependencies seem to be not well specified in default apt repositories, so we need to explicitly add them
 RUN apt-get update --yes --quiet && \
     apt-get install --yes --no-install-recommends nodejs-dev node-gyp libssl1.0-dev npm && \
-    apt-get clean && \
     rm -rf /var/lib/apt/lists/*
+
+RUN python3 -m pip install git+https://github.com/jupyterhub/jupyterhub.git@5bbb292ef5c100c2c415a662b6e5e445546a24e6
 
 USER ${NB_USER}


### PR DESCRIPTION
Reverts berkeley-dsep-infra/datahub#1467

This deploy failed somehow: https://circleci.com/gh/berkeley-dsep-infra/datahub/7891?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link