### PR TITLE
Use generic jupyterhub launcher command for datahub

### DIFF
--- a/deployments/datahub/config/common.yaml
+++ b/deployments/datahub/config/common.yaml
@@ -15,6 +15,12 @@ jupyterhub:
   hub:
     nodeSelector:
       hub.jupyter.org/node-purpose: core
+    extraConfig:
+
+      09-lab-availability: |
+        # Overrides values.yaml, until jupyterlab is upgraded in other hubs
+        # See #1468
+        c.Spawner.cmd = ['jupyterhub-singleuser']
     extraConfigMap:
       # this should be migrated to custom.profiles when that works
       profiles:

--- a/deployments/datahub/images/default/Dockerfile
+++ b/deployments/datahub/images/default/Dockerfile
@@ -191,13 +191,6 @@ ENV PYPPETEER_HOME /srv/app
 RUN pyppeteer-install
 RUN jupyter bundlerextension enable nbpdfexport.bundler --sys-prefix --py
 
-# Install JupyterLab extensions
-RUN jupyter labextension install \
-            @jupyter-widgets/jupyterlab-manager \
-            jupyter-matplotlib \
-            jupyterlab-plotly \
-            @jupyterlab/geojson-extension
-
 # Install IR kernelspec
 RUN Rscript -e "IRkernel::installspec(user = FALSE, prefix='${APP_DIR}/venv')"
 
@@ -236,5 +229,13 @@ RUN jupyter nbextension enable --py --sys-prefix qgrid
 RUN jupyter serverextension enable  --sys-prefix --py nbzip && \
     jupyter nbextension     install --sys-prefix --py nbzip && \
     jupyter nbextension     enable  --sys-prefix --py nbzip
+
+# Install JupyterLab extensions last, since we are actively experimenting with them
+RUN jupyter labextension install \
+            @jupyter-widgets/jupyterlab-manager \
+            jupyter-matplotlib \
+            jupyterlab-plotly \
+            @jupyterlab/geojson-extension
+
 
 EXPOSE 8888


### PR DESCRIPTION
Other hubs can move to this once they all have newer JupyterLabs

Ref #1468 