### PR TITLE
Update new-hub cookiecutter

### DIFF
--- a/deployments/template/cookiecutter.json
+++ b/deployments/template/cookiecutter.json
@@ -1,5 +1,5 @@
 {
     "hub_name": "dns-valid-hub-name",
     "project_name": "ucb-datahub-2018",
-    "cluster_name": "spring-2019"
+    "cluster_name": "fall-2019"
 }

--- a/deployments/template/{{cookiecutter.hub_name}}/config/common.yaml
+++ b/deployments/template/{{cookiecutter.hub_name}}/config/common.yaml
@@ -1,4 +1,25 @@
+nfsMounter:
+  enabled: false
+
+nfsPVC:
+  enabled: true
+  nfs:
+    serverIP: nfsserver1
+    shareName: export/pool0/homes
+
 jupyterhub:
+  scheduling:
+    userScheduler:
+      nodeSelector:
+        hub.jupyter.org/node-purpose: core
+  proxy:
+    nodeSelector:
+      hub.jupyter.org/node-purpose: core
+
+  hub:
+    nodeSelector:
+      hub.jupyter.org/node-purpose: core
+
   auth:
     type: google
     admin:
@@ -10,10 +31,25 @@ jupyterhub:
           # List of other admin users
 
   singleuser:
+    nodeSelector:
+      hub.jupyter.org/pool-name: gamma-pool
+    initContainers:
+      - name: volume-mount-hack
+        image: busybox
+        command: ["sh", "-c", "id && chown 1000:1000 /home/jovyan && ls -lhd /home/jovyan"]
+        securityContext:
+          runAsUser: 0
+        volumeMounts:
+        - name: home
+          mountPath: /home/jovyan
+          subPath: "_{{cookiecutter.hub_name}}/{username}"
+    storage:
+      type: static
+      static:
+        pvcName: home-nfs
+        subPath: "_{{cookiecutter.hub_name}}/{username}"
     memory:
       guarantee: 512M
       limit: 1G
     image:
       name: gcr.io/{{cookiecutter.project_name}}/{{cookiecutter.hub_name}}-user-image
-    storage:
-      type: hostPath

--- a/deployments/template/{{cookiecutter.hub_name}}/config/prod.yaml
+++ b/deployments/template/{{cookiecutter.hub_name}}/config/prod.yaml
@@ -1,8 +1,3 @@
-nfsMounter:
-  mounts:
-    # FIXME: You need to create this manually on the NFS server
-    - nfsserver1:/export/pool0/homes/_{{cookiecutter.hub_name}}=/data/homes/{{cookiecutter.hub_name}}-prod
-
 jupyterhub:
   proxy:
     # service:
@@ -18,12 +13,3 @@ jupyterhub:
       pvc:
         # This also holds logs
         storage: 4Gi
-  singleuser:
-    storage:
-      extraVolumes:
-        - name: home
-          hostPath:
-            path: /data/homes/{{cookiecutter.hub_name}}-prod/{username}
-      extraVolumeMounts:
-        - name: home
-          mountPath: /home/jovyan

--- a/deployments/template/{{cookiecutter.hub_name}}/config/staging.yaml
+++ b/deployments/template/{{cookiecutter.hub_name}}/config/staging.yaml
@@ -1,7 +1,3 @@
-nfsMounter:
-  mounts:
-    - nfsserver1:/export/pool0/homes/_{{cookiecutter.hub_name}}=/data/homes/{{cookiecutter.hub_name}}-staging
-
 jupyterhub:
   prePuller:
     continuous:
@@ -15,12 +11,3 @@ jupyterhub:
     # https:
       # hosts:
         # - {{cookiecutter.hub_name}}-staging.datahub.berkeley.edu
-  singleuser:
-    storage:
-      extraVolumes:
-        - name: home
-          hostPath:
-            path: /data/homes/{{cookiecutter.hub_name}}-staging/{username}
-      extraVolumeMounts:
-        - name: home
-          mountPath: /home/jovyan

--- a/deployments/template/{{cookiecutter.hub_name}}/image/requirements.txt
+++ b/deployments/template/{{cookiecutter.hub_name}}/image/requirements.txt
@@ -1,3 +1,4 @@
-notebook==5.7.8
+jupyterlab>=2.0
+notebook>=6.0
 nbgitpuller==0.7.2
 nbresuse==0.3.2

--- a/deployments/template/{{cookiecutter.hub_name}}/image/runtime.txt
+++ b/deployments/template/{{cookiecutter.hub_name}}/image/runtime.txt
@@ -1,1 +1,1 @@
-python-3.7
+python-3.8


### PR DESCRIPTION
- Use nfsPVC by default, not nfsMounter
- Specify nodeselectors for all components. We use gamma-pool
  for most new hubs
- Specify new default cluster name
- Newer versions of packages
- Use python 3.8 by default