### PR TITLE
Cleanup data102 docker image

### DIFF
--- a/deployments/data102/config/common.yaml
+++ b/deployments/data102/config/common.yaml
@@ -29,6 +29,11 @@ jupyterhub:
         #- placeholder
 
   hub:
+    extraConfig:
+      09-lab-availability: |
+        # Overrides values.yaml, until jupyterlab is upgraded in other hubs
+        # See #1468
+        c.Spawner.cmd = ['jupyterhub-singleuser']
     nodeSelector:
       hub.jupyter.org/node-purpose: core
 

--- a/deployments/data102/image/Dockerfile
+++ b/deployments/data102/image/Dockerfile
@@ -91,7 +91,7 @@ ADD ipython_config.py ${CONDA_PREFIX}/envs/data102/etc/ipython/
 RUN jupyter labextension install @jupyter-widgets/jupyterlab-manager@2.0.0 \
                                  jupyterlab-plotly@4.8.1  \
                                  plotlywidget@4.8.1 \
-                                 jupyterlab-matplotlib@0.7.2 \
+                                 jupyter-matplotlib@0.7.2 \
                                  @jupyterlab/geojson-extension@2.0.1
 
 # Useful for debugging any issues with conda

--- a/deployments/data102/image/Dockerfile
+++ b/deployments/data102/image/Dockerfile
@@ -11,52 +11,44 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN adduser --disabled-password --gecos "Default Jupyter user" jovyan
 
-RUN apt-get update --yes
-RUN apt-get install --yes \
-		python3.6 \
-		python3.6-venv \
-		python3.6-dev \
-		tar \
-		vim \
-		locales
-
 # Other packages for user convenience and Data100 usage
 # Install these without 'recommended' packages to keep image smaller.
-RUN apt-get install --yes --no-install-recommends \
-		build-essential \
-		ca-certificates \
-		curl \
-		default-jdk \
-		emacs-nox \
-		git \
-		htop \
-		less \
-		man \
-		mc \
-		nano \
-		openssh-client \
-		postgresql-client \
-		screen \
-		tar \
-		tmux \
-		wget
+RUN apt-get update -qq --yes && \
+    apt-get install --yes --no-install-recommends -qq \
+        build-essential \
+        ca-certificates \
+        curl \
+        default-jdk \
+        emacs-nox \
+        git \
+        htop \
+        less \
+        libpq-dev \
+        man \
+        mc \
+        nano \
+        openssh-client \
+        postgresql-client \
+        screen \
+        tar \
+        tmux \
+        wget \
+        vim \
+        locales > /dev/null
 
 RUN echo "${LC_ALL} UTF-8" > /etc/locale.gen && \
-	locale-gen
+    locale-gen
 
-# for nbconvert
-RUN apt-get install --yes \
-		# for nbconvert
-		pandoc \
-		texlive-xetex \
-		texlive-fonts-recommended \
-		texlive-generic-recommended
+RUN apt-get update -qq --yes && \
+    apt-get install --yes -qq \
+        # for nbconvert
+        pandoc \
+        texlive-xetex \
+        texlive-fonts-recommended \
+        texlive-generic-recommended \
+        wkhtmltopdf # for pdf export \
+        > /dev/null
 
-# for pdf export
-RUN apt-get install --yes wkhtmltopdf
-
-# Keep image size at a minimum
-RUN apt-get clean
 
 ENV CONDA_PREFIX /srv/conda
 ENV PATH ${CONDA_PREFIX}/bin:$PATH
@@ -73,18 +65,19 @@ USER jovyan
 # Download, install and configure the Conda environment
 
 RUN curl -o /tmp/miniconda.sh \
-	https://repo.continuum.io/miniconda/Miniconda3-4.7.10-Linux-x86_64.sh
+    https://repo.anaconda.com/miniconda/Miniconda3-4.7.12.1-Linux-x86_64.sh
 
 # Install miniconda
 RUN bash /tmp/miniconda.sh -b -u -p ${CONDA_PREFIX}
 
 RUN conda config --set always_yes yes --set changeps1 no
 RUN conda update -q conda
+RUN conda config --add channels conda-forge
 
 # Encapsulate the environment info into its own yml file (which carries
 # the name `data102` in it
 COPY environment.yml /tmp/
-RUN conda env create -q -f /tmp/environment.yml
+RUN conda env create -f /tmp/environment.yml
 
 # We modify the path directly since the `source activate data102`
 # environment won't be preserved here.
@@ -95,21 +88,14 @@ ADD jupyter_notebook_config.py  ${CONDA_PREFIX}/envs/data102/etc/jupyter/
 # Disable history.
 ADD ipython_config.py ${CONDA_PREFIX}/envs/data102/etc/ipython/
 
-# Installed in conda environment
-RUN jupyter serverextension enable --sys-prefix --py jupyterlab
-
-# Install all extensions in one shot to avoid multiple rebuilds
-RUN jupyter labextension install @jupyterlab/hub-extension \
-    @jupyter-widgets/jupyterlab-manager \
-	@jupyterlab/plotly-extension \
-	@jupyterlab/geojson-extension jupyter-matplotlib
-
-RUN jupyter serverextension enable  --sys-prefix --py nbzip
-RUN jupyter nbextension install     --sys-prefix --py nbzip
-RUN jupyter nbextension enable      --sys-prefix --py nbzip
+RUN jupyter labextension install @jupyter-widgets/jupyterlab-manager@2.0.0 \
+                                 jupyterlab-plotly@4.8.1  \
+                                 plotlywidget@4.8.1 \
+                                 jupyterlab-matplotlib@0.7.2 \
+                                 @jupyterlab/geojson-extension@2.0.1
 
 # Useful for debugging any issues with conda
-RUN conda info --all
+RUN conda info -a
 
 # Make JupyterHub ports visible
 EXPOSE 8888

--- a/deployments/data102/image/environment.yml
+++ b/deployments/data102/image/environment.yml
@@ -90,7 +90,7 @@ dependencies:
     - ipympl==0.3.3
     - nbzip==0.1.0
     - nbgitpuller==0.7.2
-    - jupyterlab==1.0.4
+    - jupyterlab==2.1.3
     - jupyter-contrib-nbextensions==0.5.1
     # We need JHub installed via pip as there's a conflict with nodejs on the
     # conda repos


### PR DESCRIPTION
This was a copy of the older unoptimized data100
Dockerfile. data100 was cleaned up in
https://github.com/berkeley-dsep-infra/datahub/pull/1480.
This commit basically copy pastes that here, and makes
some changes to fit.

We also bump jupyterlab.

Ref #1468