### PR TITLE
Improve EECS experience for vscode & desktop

### DIFF
--- a/deployments/eecs/config/common.yaml
+++ b/deployments/eecs/config/common.yaml
@@ -36,6 +36,9 @@ jupyterhub:
           # List of other admin users
 
   singleuser:
+    extraEnv:
+      # Until https://github.com/betatim/vscode-binder/pull/19 is merged
+      CODE_WORKINGDIR: /home/jovyan
     defaultUrl: "/lab"
     nodeSelector:
       hub.jupyter.org/pool-name: gamma-pool

--- a/deployments/eecs/image/apt.txt
+++ b/deployments/eecs/image/apt.txt
@@ -11,6 +11,6 @@ firefox
 # And a text editor
 gedit
 # And a terminal
-gnome-terminal
+xfce4-terminal
 # Install JDK
 default-jdk


### PR DESCRIPTION
- Install xfce4-terminal instead of GNOME terminal
  Brings in fewer dependencies maybe (thanks @ryanlovett)

- Start vscode in home directory
  Until https://github.com/betatim/vscode-binder/pull/19
  is merged
