### PR TITLE
Install qt5 from apt

### DIFF
--- a/deployments/eecs/image/apt.txt
+++ b/deployments/eecs/image/apt.txt
@@ -14,3 +14,6 @@ gedit
 xfce4-terminal
 # Install JDK
 default-jdk
+# Qt for pyqt based exercises in our desktop environment
+# https://github.com/berkeley-dsep-infra/datahub/issues/1505
+qt5-default


### PR DESCRIPTION
pyqt5 is bindings, you still actually need qt itself

Ref #1505 