### PR TITLE
Bump workshop hub limit to 200

### DIFF
--- a/deployments/workshop/config/common.yaml
+++ b/deployments/workshop/config/common.yaml
@@ -28,8 +28,8 @@ jupyterhub:
         # Overrides values.yaml, until jupyterlab is upgraded in other hubs
         # See #1468
         c.Spawner.cmd = ['jupyterhub-singleuser']
-    # No more than 150 users at any given time
-    activeServerLimit: 150
+    # No more than 200 users at any given time
+    activeServerLimit: 200
     nodeSelector:
       hub.jupyter.org/node-purpose: core
   proxy:


### PR DESCRIPTION
Eric Van Dusen says there will be upto 200 users at
the National Pedagogy Workshop