### PR TITLE
Reduce autoscaler headroom

### DIFF
--- a/deployments/data100/config/prod.yaml
+++ b/deployments/data100/config/prod.yaml
@@ -12,4 +12,4 @@ jupyterhub:
   scheduling:
     userPlaceholder:
       enabled: true
-      replicas: 80
+      replicas: 10

--- a/deployments/datahub/config/prod.yaml
+++ b/deployments/datahub/config/prod.yaml
@@ -38,4 +38,4 @@ jupyterhub:
   scheduling:
     userPlaceholder:
       enabled: true
-      replicas: 80
+      replicas: 10

--- a/deployments/prob140/config/prod.yaml
+++ b/deployments/prob140/config/prod.yaml
@@ -2,7 +2,7 @@ jupyterhub:
   scheduling:
     userPlaceholder:
       enabled: true
-      replicas: 50
+      replicas: 10
   proxy:
     service:
       loadBalancerIP: 35.184.101.216

--- a/deployments/r/config/prod.yaml
+++ b/deployments/r/config/prod.yaml
@@ -13,4 +13,4 @@ jupyterhub:
   scheduling:
     userPlaceholder:
       enabled: true
-      replicas: 50
+      replicas: 10


### PR DESCRIPTION
We generally keep 1 full node of headroom, to prevent
stalls due to autoscaling latency. That isn't required right now,
since the summer is sleepy. So let's turn it off.