### PR TITLE
Reduce resource requests for hub, proxy & traefik

### DIFF
--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -37,13 +37,16 @@ jupyterhub:
     chp:
       resources:
         requests:
+          # FIXME: We want no guarantees here!!!
+          # This is lowest possible value
+          cpu: 0.001
           memory: 64Mi
         limits:
           memory: 256Mi
-    nginx:
+    traefik:
       resources:
         requests:
-          memory: 256Mi
+          memory: 96Mi
         limits:
           memory: 512Mi
     https:
@@ -94,6 +97,9 @@ jupyterhub:
       enabled: true
     resources:
       requests:
+        # Very small unit, since we don't want any CPU guarantees
+        # FIXME: Can't seem to get this to null?
+        cpu: 0.001
         memory: 256Mi
       limits:
         memory: 1Gi


### PR DESCRIPTION
Made a dashboard
(http://grafana.datahub.berkeley.edu/d/tdPns4WMk/core-pods-resource-usage?orgId=1&var-Kind=All)
showing actual resource usage, which is fair bit lesser than
our guarantees. I'm trying to reduce the number of core nodes,
and this should help