### PR TITLE
Switch to newer core-pool

### DIFF
--- a/deployments/buds-2020/config/common.yaml
+++ b/deployments/buds-2020/config/common.yaml
@@ -11,14 +11,14 @@ jupyterhub:
   scheduling:
     userScheduler:
       nodeSelector:
-        hub.jupyter.org/node-purpose: core
+        hub.jupyter.org/pool-name: core-pool
   proxy:
     nodeSelector:
-      hub.jupyter.org/node-purpose: core
+      hub.jupyter.org/pool-name: core-pool
 
   hub:
     nodeSelector:
-      hub.jupyter.org/node-purpose: core
+      hub.jupyter.org/pool-name: core-pool
     extraConfig:
       09-lab-availability: |
         # Overrides values.yaml, until jupyterlab is upgraded in other hubs

--- a/deployments/data102/config/common.yaml
+++ b/deployments/data102/config/common.yaml
@@ -10,10 +10,10 @@ jupyterhub:
   scheduling:
     userScheduler:
       nodeSelector:
-        hub.jupyter.org/node-purpose: core
+        hub.jupyter.org/pool-name: core-pool
   proxy:
     nodeSelector:
-      hub.jupyter.org/node-purpose: core
+      hub.jupyter.org/pool-name: core-pool
   auth:
     type: google
     admin:
@@ -35,7 +35,7 @@ jupyterhub:
         # See #1468
         c.Spawner.cmd = ['jupyterhub-singleuser']
     nodeSelector:
-      hub.jupyter.org/node-purpose: core
+      hub.jupyter.org/pool-name: core-pool
 
   singleuser:
     nodeSelector:

--- a/deployments/datahub/config/common.yaml
+++ b/deployments/datahub/config/common.yaml
@@ -11,10 +11,10 @@ jupyterhub:
   scheduling:
     userScheduler:
       nodeSelector:
-        hub.jupyter.org/node-purpose: core
+        hub.jupyter.org/pool-name: core-pool
   hub:
     nodeSelector:
-      hub.jupyter.org/node-purpose: core
+      hub.jupyter.org/pool-name: core-pool
     extraConfig:
 
       09-lab-availability: |
@@ -71,7 +71,7 @@ jupyterhub:
               mountPath: /home/jovyan/shared/module-leads
   proxy:
     nodeSelector:
-      hub.jupyter.org/node-purpose: core
+      hub.jupyter.org/pool-name: core-pool
   auth:
     type: custom # This enables canvas auth
     admin:

--- a/deployments/eecs/config/common.yaml
+++ b/deployments/eecs/config/common.yaml
@@ -11,10 +11,10 @@ jupyterhub:
   scheduling:
     userScheduler:
       nodeSelector:
-        hub.jupyter.org/node-purpose: core
+        hub.jupyter.org/pool-name: core-pool
   proxy:
     nodeSelector:
-      hub.jupyter.org/node-purpose: core
+      hub.jupyter.org/pool-name: core-pool
 
   hub:
     extraConfig:
@@ -23,7 +23,7 @@ jupyterhub:
         # See #1468
         c.Spawner.cmd = ['jupyterhub-singleuser']
     nodeSelector:
-      hub.jupyter.org/node-purpose: core
+      hub.jupyter.org/pool-name: core-pool
 
   auth:
     type: google

--- a/deployments/julia/config/common.yaml
+++ b/deployments/julia/config/common.yaml
@@ -11,13 +11,13 @@ jupyterhub:
   scheduling:
     userScheduler:
       nodeSelector:
-        hub.jupyter.org/node-purpose: core
+        hub.jupyter.org/pool-name: core-pool
   hub:
     nodeSelector:
-      hub.jupyter.org/node-purpose: core
+      hub.jupyter.org/pool-name: core-pool
   proxy:
     nodeSelector:
-      hub.jupyter.org/node-purpose: core
+      hub.jupyter.org/pool-name: core-pool
   auth:
     type: custom  # uses canvas auth, see hub/values.yaml
     admin:

--- a/deployments/prob140/config/common.yaml
+++ b/deployments/prob140/config/common.yaml
@@ -11,10 +11,10 @@ jupyterhub:
   scheduling:
     userScheduler:
       nodeSelector:
-        hub.jupyter.org/node-purpose: core
+        hub.jupyter.org/pool-name: core-pool
   proxy:
     nodeSelector:
-      hub.jupyter.org/node-purpose: core
+      hub.jupyter.org/pool-name: core-pool
   auth:
     type: google
     admin:
@@ -39,7 +39,7 @@ jupyterhub:
         # See #1468
         c.Spawner.cmd = ['jupyterhub-singleuser']
     nodeSelector:
-      hub.jupyter.org/node-purpose: core
+      hub.jupyter.org/pool-name: core-pool
 
   singleuser:
     nodeSelector:

--- a/deployments/r/config/common.yaml
+++ b/deployments/r/config/common.yaml
@@ -12,13 +12,13 @@ jupyterhub:
   scheduling:
     userScheduler:
       nodeSelector:
-        hub.jupyter.org/node-purpose: core
+        hub.jupyter.org/pool-name: core-pool
   proxy:
     nodeSelector:
-      hub.jupyter.org/node-purpose: core
+      hub.jupyter.org/pool-name: core-pool
   hub:
     nodeSelector:
-      hub.jupyter.org/node-purpose: core
+      hub.jupyter.org/pool-name: core-pool
     extraConfigMap:
       # this should be migrated to custom.profiles when that works
       profiles:

--- a/deployments/stat89a/config/common.yaml
+++ b/deployments/stat89a/config/common.yaml
@@ -2,13 +2,13 @@ jupyterhub:
   scheduling:
     userScheduler:
       nodeSelector:
-        hub.jupyter.org/node-purpose: core
+        hub.jupyter.org/pool-name: core-pool
   proxy:
     nodeSelector:
-      hub.jupyter.org/node-purpose: core
+      hub.jupyter.org/pool-name: core-pool
   hub:
     nodeSelector:
-      hub.jupyter.org/node-purpose: core
+      hub.jupyter.org/pool-name: core-pool
   auth:
     type: google
     admin:

--- a/deployments/template/{{cookiecutter.hub_name}}/config/common.yaml
+++ b/deployments/template/{{cookiecutter.hub_name}}/config/common.yaml
@@ -11,14 +11,14 @@ jupyterhub:
   scheduling:
     userScheduler:
       nodeSelector:
-        hub.jupyter.org/node-purpose: core
+        hub.jupyter.org/pool-name: core-pool
   proxy:
     nodeSelector:
-      hub.jupyter.org/node-purpose: core
+      hub.jupyter.org/pool-name: core-pool
 
   hub:
     nodeSelector:
-      hub.jupyter.org/node-purpose: core
+      hub.jupyter.org/pool-name: core-pool
 
   auth:
     type: google

--- a/deployments/workshop/config/common.yaml
+++ b/deployments/workshop/config/common.yaml
@@ -21,7 +21,7 @@ jupyterhub:
   scheduling:
     userScheduler:
       nodeSelector:
-        hub.jupyter.org/node-purpose: core
+        hub.jupyter.org/pool-name: core-pool
   hub:
     extraConfig:
       09-lab-availability: |
@@ -31,10 +31,10 @@ jupyterhub:
     # No more than 200 users at any given time
     activeServerLimit: 200
     nodeSelector:
-      hub.jupyter.org/node-purpose: core
+      hub.jupyter.org/pool-name: core-pool
   proxy:
     nodeSelector:
-      hub.jupyter.org/node-purpose: core
+      hub.jupyter.org/pool-name: core-pool
   auth:
     type: dummy
     admin:


### PR DESCRIPTION
- We have some e2 reservations we should always be using.
  With gamma-pool not running, this is a good time to move
  core-pools over
- Core pool is a good candidate for e2 instance with reservation,
  since they will pretty much always be there. This makes them
  cheaper than n1 instances with sustained use discounts.
- With tuning memory & CPU requests, I'm hoping we also need
  fewer resources for our core pool. As such, these are e2-highmem-4
  instances, compared to n1-highmem-8 instances we were using earlier.
  These have 32G of RAM each, which honestly should be more than
  enough. Let's tweak until it is.
- We start using the 'core-pool' label for core pool as well,
  instead of the 'node-purpose' label. This makes it consistent
  with our other pool labels.
- We use standard disks rather than ssd disks for boot disk. This
  makes them much cheaper, and we don't really update images on
  these nodes often enough for it to matter.