### PR TITLE
Move all hubs to gamma pool

### DIFF
--- a/deployments/buds-2020/config/common.yaml
+++ b/deployments/buds-2020/config/common.yaml
@@ -49,7 +49,7 @@ jupyterhub:
 
   singleuser:
     nodeSelector:
-      hub.jupyter.org/pool-name: alpha-pool
+      hub.jupyter.org/pool-name: gamma-pool
     initContainers:
       - name: volume-mount-hack
         image: busybox

--- a/deployments/data100/config/common.yaml
+++ b/deployments/data100/config/common.yaml
@@ -132,7 +132,7 @@ jupyterhub:
           subPath: _shared
           readOnly: true
     nodeSelector:
-      hub.jupyter.org/pool-name: beta-pool
+      hub.jupyter.org/pool-name: gamma-pool
     initContainers:
       - name: volume-mount-hack
         image: busybox

--- a/deployments/data102/config/common.yaml
+++ b/deployments/data102/config/common.yaml
@@ -39,7 +39,7 @@ jupyterhub:
 
   singleuser:
     nodeSelector:
-      hub.jupyter.org/pool-name: alpha-pool
+      hub.jupyter.org/pool-name: gamma-pool
     initContainers:
       - name: volume-mount-hack
         image: busybox

--- a/deployments/datahub/config/common.yaml
+++ b/deployments/datahub/config/common.yaml
@@ -180,7 +180,7 @@ jupyterhub:
           - tongshen
   singleuser:
     nodeSelector:
-      hub.jupyter.org/pool-name: alpha-pool
+      hub.jupyter.org/pool-name: gamma-pool
     storage:
       type: none
     memory:

--- a/deployments/desktop-test/config/common.yaml
+++ b/deployments/desktop-test/config/common.yaml
@@ -21,7 +21,7 @@ jupyterhub:
   singleuser:
     defaultUrl: /desktop
     nodeSelector:
-      hub.jupyter.org/pool-name: alpha-pool
+      hub.jupyter.org/pool-name: gamma-pool
     initContainers:
       - name: volume-mount-hack
         image: busybox

--- a/deployments/eecs/config/common.yaml
+++ b/deployments/eecs/config/common.yaml
@@ -41,7 +41,7 @@ jupyterhub:
       CODE_WORKINGDIR: /home/jovyan
     defaultUrl: "/lab"
     nodeSelector:
-      hub.jupyter.org/pool-name: alpha-pool
+      hub.jupyter.org/pool-name: gamma-pool
     initContainers:
       - name: volume-mount-hack
         image: busybox

--- a/deployments/julia/config/common.yaml
+++ b/deployments/julia/config/common.yaml
@@ -30,7 +30,7 @@ jupyterhub:
 
   singleuser:
     nodeSelector:
-      hub.jupyter.org/pool-name: alpha-pool
+      hub.jupyter.org/pool-name: gamma-pool
     initContainers:
       - name: volume-mount-hack
         image: busybox

--- a/deployments/prob140/config/common.yaml
+++ b/deployments/prob140/config/common.yaml
@@ -43,7 +43,7 @@ jupyterhub:
 
   singleuser:
     nodeSelector:
-      hub.jupyter.org/pool-name: alpha-pool
+      hub.jupyter.org/pool-name: gamma-pool
     initContainers:
       - name: volume-mount-hack
         image: busybox

--- a/deployments/r/config/common.yaml
+++ b/deployments/r/config/common.yaml
@@ -70,7 +70,7 @@ jupyterhub:
 
   singleuser:
     nodeSelector:
-      hub.jupyter.org/pool-name: alpha-pool
+      hub.jupyter.org/pool-name: gamma-pool
     initContainers:
       - name: volume-mount-hack
         image: busybox

--- a/deployments/stat89a/config/common.yaml
+++ b/deployments/stat89a/config/common.yaml
@@ -28,7 +28,7 @@ jupyterhub:
 
   singleuser:
     nodeSelector:
-      hub.jupyter.org/pool-name: alpha-pool
+      hub.jupyter.org/pool-name: gamma-pool
     memory:
       guarantee: 512M
       limit: 1G

--- a/deployments/template/{{cookiecutter.hub_name}}/config/common.yaml
+++ b/deployments/template/{{cookiecutter.hub_name}}/config/common.yaml
@@ -32,7 +32,7 @@ jupyterhub:
 
   singleuser:
     nodeSelector:
-      hub.jupyter.org/pool-name: alpha-pool
+      hub.jupyter.org/pool-name: gamma-pool
     initContainers:
       - name: volume-mount-hack
         image: busybox

--- a/deployments/workshop/config/common.yaml
+++ b/deployments/workshop/config/common.yaml
@@ -45,7 +45,7 @@ jupyterhub:
   singleuser:
     nodeSelector:
       # Co-locate with datahub, since workshop shares its image
-      hub.jupyter.org/pool-name: alpha-pool
+      hub.jupyter.org/pool-name: gamma-pool
     image:
       # Matches datahub image
       name: gcr.io/ucb-datahub-2018/primary-user-image


### PR DESCRIPTION
We have a 16-core, 128G Mem commitment of e2 instances.
We can use 8-cores and 64G of it on core nodes. We now move
all the other hub user pods to the gamma pool, which has
e2 instances. This makes sure we use our full set of commitments,
and minimize running nodes we don't need.

See https://github.com/berkeley-dsep-infra/datahub/pull/1546
for similar PR