### PR TITLE
Lower CPU request for user-scheduler

### DIFF
--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -30,6 +30,8 @@ jupyterhub:
       enabled: true
       resources:
         requests:
+          # FIXME: Just unset this?
+          cpu: 0.01
           memory: 64Mi
         limits:
           memory: 512Mi


### PR DESCRIPTION
At 0.05 each, they add up pretty fast - especially on
nodes with just 4 CPUs. I'm trying to bring everything
into one core node.