### PR TITLE
Add DISPLAY env var to eecs hub

### DIFF
--- a/deployments/eecs/config/common.yaml
+++ b/deployments/eecs/config/common.yaml
@@ -39,6 +39,9 @@ jupyterhub:
     extraEnv:
       # Until https://github.com/betatim/vscode-binder/pull/19 is merged
       CODE_WORKINGDIR: /home/jovyan
+      # Tell code where to display GUIs
+      # The VNC /desktop link must be opened already for this to work
+      DISPLAY: ":1.0"
     defaultUrl: "/lab"
     nodeSelector:
       hub.jupyter.org/pool-name: alpha-pool


### PR DESCRIPTION
Along with '%gui qt5', this lets users launch GUI applications
from notebook to the VNC desktop!

Stolen from https://github.com/manics/jupyter-omeroanalysis-desktop/blob/napari-binder/napari.ipynb

Ref #1505