### PR TITLE
Give EECS hub more RAM

### DIFF
--- a/deployments/eecs/config/common.yaml
+++ b/deployments/eecs/config/common.yaml
@@ -58,7 +58,7 @@ jupyterhub:
         pvcName: home-nfs
         subPath: "_eecs/{username}"
     memory:
-      guarantee: 512M
-      limit: 1G
+      guarantee: 1G
+      limit: 4G
     image:
       name: gcr.io/ucb-datahub-2018/eecs-user-image


### PR DESCRIPTION
They need it (currently) for desktop usage. We might
dial it back later.

Ref #1505