### PR TITLE
Give EECS hub even more RAM

### DIFF
--- a/deployments/eecs/config/common.yaml
+++ b/deployments/eecs/config/common.yaml
@@ -58,7 +58,7 @@ jupyterhub:
         pvcName: home-nfs
         subPath: "_eecs/{username}"
     memory:
-      guarantee: 1G
+      guarantee: 4G
       limit: 4G
     image:
       name: gcr.io/ucb-datahub-2018/eecs-user-image


### PR DESCRIPTION
Turns out running a Linux Desktop takes a lot of RAM

Ref #1505