### PR TITLE
Enable user-placeholders for EECS

### DIFF
--- a/deployments/eecs/config/prod.yaml
+++ b/deployments/eecs/config/prod.yaml
@@ -10,3 +10,7 @@ jupyterhub:
       pvc:
         # This also holds logs
         storage: 4Gi
+  scheduling:
+    userPlaceholder:
+      enabled: true
+      replicas: 30


### PR DESCRIPTION
Make sure there's enough room for users to start without
having to wait for a new node to come up. This might
be a little wasteful, but important to have a good experience
right now.