### PR TITLE
Increase eecs hub limit some more

### DIFF
--- a/deployments/eecs/config/common.yaml
+++ b/deployments/eecs/config/common.yaml
@@ -59,6 +59,6 @@ jupyterhub:
         subPath: "_eecs/{username}"
     memory:
       guarantee: 4G
-      limit: 4G
+      limit: 8G
     image:
       name: gcr.io/ucb-datahub-2018/eecs-user-image


### PR DESCRIPTION
Users are consistently using at least 4G. Increasing the
guarantee earlier makes sure they get at least that. However,
I want to set the limit higher to see how much they actually
use.

Ref #1505