### PR TITLE
Remove volume-mount-hack initcontainers

### DIFF
--- a/deployments/buds-2020/config/common.yaml
+++ b/deployments/buds-2020/config/common.yaml
@@ -34,16 +34,6 @@ jupyterhub:
   singleuser:
     nodeSelector:
       hub.jupyter.org/pool-name: gamma-pool
-    initContainers:
-      - name: volume-mount-hack
-        image: busybox
-        command: ["sh", "-c", "id && chown 1000:1000 /home/jovyan && ls -lhd /home/jovyan"]
-        securityContext:
-          runAsUser: 0
-        volumeMounts:
-        - name: home
-          mountPath: /home/jovyan
-          subPath: "{username}"
     storage:
       type: static
       static:

--- a/deployments/data100/config/common.yaml
+++ b/deployments/data100/config/common.yaml
@@ -105,19 +105,6 @@ jupyterhub:
           readOnly: true
     nodeSelector:
       hub.jupyter.org/pool-name: gamma-pool
-    initContainers:
-      - name: volume-mount-hack
-        image: busybox
-        command: ["sh", "-c", "id && chown 1000:1000 /home/jovyan && chown 1000:1000 /home/jovyan/shared"]
-        securityContext:
-          runAsUser: 0
-        volumeMounts:
-        - name: home
-          mountPath: /home/jovyan
-          subPath: "{username}"
-        - name: home
-          mountPath: /home/jovyan/shared
-          subPath: _shared
     storage:
       type: static
       static:

--- a/deployments/data102/config/common.yaml
+++ b/deployments/data102/config/common.yaml
@@ -38,16 +38,6 @@ jupyterhub:
   singleuser:
     nodeSelector:
       hub.jupyter.org/pool-name: gamma-pool
-    initContainers:
-      - name: volume-mount-hack
-        image: busybox
-        command: ["sh", "-c", "id && chown 1000:1000 /home/jovyan && ls -lhd /home/jovyan"]
-        securityContext:
-          runAsUser: 0
-        volumeMounts:
-        - name: home
-          mountPath: /home/jovyan
-          subPath: "{username}"
     storage:
       type: static
       static:

--- a/deployments/eecs/config/common.yaml
+++ b/deployments/eecs/config/common.yaml
@@ -62,16 +62,6 @@ jupyterhub:
     defaultUrl: "/lab"
     nodeSelector:
       hub.jupyter.org/pool-name: gamma-pool
-    initContainers:
-      - name: volume-mount-hack
-        image: busybox
-        command: ["sh", "-c", "id && chown 1000:1000 /home/jovyan && ls -lhd /home/jovyan"]
-        securityContext:
-          runAsUser: 0
-        volumeMounts:
-        - name: home
-          mountPath: /home/jovyan
-          subPath: "{username}"
     storage:
       type: static
       static:

--- a/deployments/julia/config/common.yaml
+++ b/deployments/julia/config/common.yaml
@@ -28,16 +28,6 @@ jupyterhub:
   singleuser:
     nodeSelector:
       hub.jupyter.org/pool-name: gamma-pool
-    initContainers:
-      - name: volume-mount-hack
-        image: busybox
-        command: ["sh", "-c", "id && chown 1000:1000 /home/jovyan && ls -lhd /home/jovyan"]
-        securityContext:
-          runAsUser: 0
-        volumeMounts:
-        - name: home
-          mountPath: /home/jovyan
-          subPath: "{username}"
     storage:
       type: static
       static:

--- a/deployments/prob140/config/common.yaml
+++ b/deployments/prob140/config/common.yaml
@@ -41,16 +41,6 @@ jupyterhub:
   singleuser:
     nodeSelector:
       hub.jupyter.org/pool-name: gamma-pool
-    initContainers:
-      - name: volume-mount-hack
-        image: busybox
-        command: ["sh", "-c", "id && chown 1000:1000 /home/jovyan && ls -lhd /home/jovyan"]
-        securityContext:
-          runAsUser: 0
-        volumeMounts:
-        - name: home
-          mountPath: /home/jovyan
-          subPath: "{username}"
     storage:
       type: static
       static:

--- a/deployments/r/config/common.yaml
+++ b/deployments/r/config/common.yaml
@@ -60,16 +60,6 @@ jupyterhub:
   singleuser:
     nodeSelector:
       hub.jupyter.org/pool-name: gamma-pool
-    initContainers:
-      - name: volume-mount-hack
-        image: busybox
-        command: ["sh", "-c", "id && chown 1000:1000 /home/rstudio && ls -lhd /home/rstudio"]
-        securityContext:
-          runAsUser: 0
-        volumeMounts:
-        - name: home
-          mountPath: /home/rstudio
-          subPath: "{username}"
     storage:
       type: static
       homeMountPath: /home/rstudio

--- a/deployments/template/{{cookiecutter.hub_name}}/config/common.yaml
+++ b/deployments/template/{{cookiecutter.hub_name}}/config/common.yaml
@@ -30,16 +30,6 @@ jupyterhub:
   singleuser:
     nodeSelector:
       hub.jupyter.org/pool-name: gamma-pool
-    initContainers:
-      - name: volume-mount-hack
-        image: busybox
-        command: ["sh", "-c", "id && chown 1000:1000 /home/jovyan && ls -lhd /home/jovyan"]
-        securityContext:
-          runAsUser: 0
-        volumeMounts:
-        - name: home
-          mountPath: /home/jovyan
-          subPath: "_{{cookiecutter.hub_name}}/{username}"
     storage:
       type: static
       static:

--- a/deployments/workshop/config/common.yaml
+++ b/deployments/workshop/config/common.yaml
@@ -46,16 +46,6 @@ jupyterhub:
     image:
       # Matches datahub image
       name: gcr.io/ucb-datahub-2018/primary-user-image
-    initContainers:
-      - name: volume-mount-hack
-        image: busybox
-        command: ["sh", "-c", "id && chown 1000:1000 /home/jovyan && ls -lhd /home/jovyan"]
-        securityContext:
-          runAsUser: 0
-        volumeMounts:
-        - name: home
-          mountPath: /home/jovyan
-          subPath: "{username}"
     storage:
       type: static
       static:


### PR DESCRIPTION
We already use anonuid=1000,anongid=1000 in our NFS exports,
so the NFS dirs have the correct permissions for new users.
So we don't actually need the hack anymore. This reduces the
number of containers needed per-user.