### PR TITLE
Cleanup workshop hub config

### DIFF
--- a/deployments/workshop/config/common.yaml
+++ b/deployments/workshop/config/common.yaml
@@ -42,7 +42,7 @@ jupyterhub:
   singleuser:
     nodeSelector:
       # Co-locate with datahub, since workshop shares its image
-      hub.jupyter.org/pool-name: gamma-pool
+      hub.jupyter.org/pool-name: alpha-pool
     image:
       # Matches datahub image
       name: gcr.io/ucb-datahub-2018/primary-user-image

--- a/deployments/workshop/config/prod.yaml
+++ b/deployments/workshop/config/prod.yaml
@@ -1,8 +1,7 @@
 jupyterhub:
   scheduling:
     userPlaceholder:
-      enabled: true
-      replicas: 50
+      enabled: false
 
   proxy:
   #   service:


### PR DESCRIPTION
- No longer need placeholders, workshop is over
- datahub is back on alpha pool, let's stop putting this on
  gamma pool. This will kick the datahub image off gamma pool