### PR TITLE
Upgrade Prometheus / grafana

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -488,3 +488,11 @@ workflows:
               only:
                 - staging
                 - prod
+  deploy-support:
+    jobs:
+      - deploy-support:
+          filters:
+            branches:
+              # We don't have staging / prod for our support cluster
+              # So we deploy only when deploying staging
+              only: staging

--- a/support/requirements.yaml
+++ b/support/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
  - name: prometheus
-   version: 9.1.0
+   version: 11.11.1
    repository: https://kubernetes-charts.storage.googleapis.com
  - name: grafana
-   version: 3.8.5
+   version: 5.5.5
    repository: https://kubernetes-charts.storage.googleapis.com

--- a/support/values.yaml
+++ b/support/values.yaml
@@ -27,6 +27,8 @@ prometheus:
       type: ClusterIP
 
 grafana:
+  persistence:
+    storageClassName: standard
   deploymentStrategy:
     type: Recreate
 


### PR DESCRIPTION
I've manually performed the upgrade.

This reverts commit da0c900f373578c49109808ed065377efdc3b57c.

We re-enable automatic deploys of the support charts!
The migration issue has been fixed - needed a run of
https://github.com/hickeyma/helm-mapkubeapis to support
newer kubernetes versions