### PR TITLE
datahub: Switch to using python 3.7

### DIFF
--- a/deployments/datahub/images/default/Dockerfile
+++ b/deployments/datahub/images/default/Dockerfile
@@ -182,7 +182,7 @@ COPY infra-requirements.txt /tmp/infra-requirements.txt
 
 RUN conda env update -p ${CONDA_DIR} -f /tmp/environment.yml
 
-RUN pip install --no-cache numpy==1.16.1 cython==0.29.21
+RUN pip install --no-cache numpy==1.19.1 cython==0.29.21
 RUN pip install --no-cache -r /tmp/requirements.txt
 # Set up nbpdf dependencies
 ENV PYPPETEER_HOME ${CONDA_DIR}
@@ -195,12 +195,6 @@ RUN Rscript -e "IRkernel::installspec(user = FALSE, prefix='${CONDA_DIR}')"
 # hmms needs to be installed after cython, for ce88 and ls88-3
 # FIXME: Temporarily disabled, running into https://github.com/lopatovsky/HMMs/issues/13
 # RUN pip install --no-cache-dir hmms==0.1
-
-# Cartopy needs to be installed after cython, for eps 88
-RUN pip install --no-cache-dir Cartopy==0.17.0
-
-# hdbscan needs to be installed after cython, for physics 188
-RUN pip install --no-cache-dir hdbscan==0.8.22
 
 COPY d8extension.bash /usr/local/sbin/d8extension.bash
 RUN /usr/local/sbin/d8extension.bash

--- a/deployments/datahub/images/default/environment.yml
+++ b/deployments/datahub/images/default/environment.yml
@@ -1,4 +1,4 @@
 dependencies:
 - nodejs==14.*
 - pip==20.*
-- python==3.6.*
+- python==3.7.*

--- a/deployments/datahub/images/default/requirements.txt
+++ b/deployments/datahub/images/default/requirements.txt
@@ -71,7 +71,7 @@ scikit-image==0.13.1
 Keras==2.0.8
 keras-vis==0.4.1
 tables==3.6.1
-opencv-python==3.3.0.10
+opencv-python==4.4.0.42
 
 # astr 128/256; spring 2020
 astroquery==0.3.10

--- a/deployments/datahub/images/default/requirements.txt
+++ b/deployments/datahub/images/default/requirements.txt
@@ -3,137 +3,139 @@
 nbzip==0.0.4
 #
 # data8; foundation
-datascience==0.15.1
-matplotlib==3.1.0
-pandas==0.23.4
-scipy==1.2.0
-statsmodels==0.8.0
-okpy==1.12.5
-ipympl==0.2.1
-folium==0.9.1
+datascience==0.15.6
+matplotlib==3.3.1
+pandas==1.1.0
+scipy==1.5.2
+statsmodels==0.11.1
+okpy==1.18.1
+ipympl==0.5.7
+folium==0.11
 #
 # r
-jupyter-server-proxy==1.0.1
-jupyter-rsession-proxy==1.0b6
+jupyter-server-proxy==1.5.0
+jupyter-rsession-proxy==1.2
 #
 # cogsci88;
 ggplot==0.11.5
 #
 # geog88; spring 2018
 mplleaflet==0.0.5
-geopandas==0.3.0
-geopy==1.11.0
-pysal==1.14.3
-https://github.com/matplotlib/basemap/archive/v1.1.0.tar.gz
-rtree==0.8.3
-netCDF4==1.3.1
+geopandas==0.8.1
+geopy==2.0.0
+pysal==2.3.0
+https://github.com/matplotlib/basemap/archive/v1.2.2rel.tar.gz
+rtree==0.9.4
+netCDF4==1.5.4
 #
 # cogsci131; spring 2018
 nose==1.3.7
 #
 # modules
-scikit-learn==0.21.3
-seaborn==0.9.0
-bokeh==0.12.6
+scikit-learn==0.23.2
+seaborn==0.10.1
+bokeh==2.1.1
 decorator==4.4.2
 networkx==2.4
 pygame==1.9.6
-nltk==3.4.5
-beautifulsoup4==4.6.0
-spacy==1.9.0
-qgrid==1.1.1
+nltk==3.5
+beautifulsoup4==4.9.1
+spacy==2.3.2
+qgrid==1.3.1
 #
 # ls 88-3; neuro
-lxml==3.8.0
-tqdm==4.15.0
-mne==0.14.1
-nibabel==2.1.0
-h5py==2.7.0
-pillow==4.2.1
-numexpr==2.6.4
-openpyxl==2.4.8
-nilearn==0.3.1
+lxml==4.5.2
+tqdm==4.48.2
+mne==0.20.7
+nibabel==3.1.1
+h5py==2.10.0
+pillow==7.2.0
+numexpr==2.7.1
+openpyxl==3.0.4
+nilearn==0.6.2
 #
 # ls 88-4, economic development connector
-gmaps==0.8.0
+gmaps==0.9.0
 #
 # phys 151;
-emcee==2.2.1
-daft==0.0.4
-corner==2.0.1
+emcee==3.0.2
+daft==0.1.0
+corner==2.1.0
 #
 # ce88;
 pymdptoolbox==4.0b3
 #
 # data-x; DL
-tensorflow==2.1.0
-scikit-image==0.13.1
-Keras==2.0.8
+tensorflow==2.3.0
+scikit-image==0.17.2
+Keras==2.4.3
 keras-vis==0.4.1
 tables==3.6.1
 opencv-python==4.4.0.42
 
 # astr 128/256; spring 2020
-astroquery==0.3.10
+astroquery==0.4.1
 astropy==4.0
 dustmaps==1.0.4
 george==0.3.1
-exoplanet==0.2.4
-pymc3==3.8
-torch==1.3.1
-torchvision==0.2.2
+exoplanet==0.3.2
+pymc3==3.9.3
+torch==1.6.0
+torchvision==0.7.0
 
 # eep 153; spring 2019
-requests==2.21.0
-Pint==0.9
+requests==2.24.0
+Pint==0.14
 # Google spreadsheets, Eric Van Dusen / Keeley Takimoto / Modules
-gspread-pandas==1.2.1
-gspread==3.1.0
+gspread-pandas==2.2.3
+gspread==3.6.0
 
 # psych101d; fall 2019; cfrye
-Theano==1.0.4
+Theano==1.0.5
 
 # eps 109; fall 2019
-ffmpeg-python==0.1.17
+ffmpeg-python==0.2.0
+Cartopy==0.18.0
 
 # data 88; spring 2020
-plotly==4.0.0
+plotly==4.9.0
 mpmath==1.1.0
-sympy==1.4
-mcautograder==0.0.5
-chart-studio==1.0.0
-csaps==0.5.0
-nb2pdf==0.5.0
+sympy==1.6.2
+mcautograder==0.0.6
+chart-studio==1.1.0
+csaps==1.0.2
+nb2pdf==0.6.2
 git+https://github.com/ucbds-infra/otter-grader.git@655813fb531f1cf098f8df67df02a03b727b0493
 nbforms==0.5.1
 
 # issue #875, global 150Q/pacs 190 - fall 2019
-wordcloud==1.5.0
+wordcloud==1.8.0
 
 # issue #929, SW 282 - fall 2019
-pyreadstat==0.2.8
+pyreadstat==1.0.0
 
 # issue 954, EPS24 - fall 2019
-xarray==0.12.3
-dask==2.3.0
+xarray==0.16.0
+dask==2.23.0
 
 # issue 1001, Physics 188/288 - fall 2019
-umap-learn==0.3.10
+umap-learn==0.4.6
+hdbscan==0.8.26
 
 # espm 125/bio 105; fall 2019
-shapely==1.6.4.post2
+shapely==1.7.0
 pyvcf==0.6.8
-bitarray==0.8.3
+bitarray==1.5.2
 nlmpy==0.1.5
 
 # physics 188/288 fall, 2019
-getdist==0.3.3
-tensorflow-hub==0.7.0
-tensorflow-probability==0.8.0
+getdist==1.1.2
+tensorflow-hub==0.8.0
+tensorflow-probability==0.11.0
 
 # mcb 163l, fall 2019
 pydot==1.4.1
-allensdk==0.16.0
+allensdk==2.1.0
 
 # cs16A/B, spring 2020
-lcapy==0.44.1
+lcapy==0.66.0

--- a/deployments/datahub/images/default/requirements.txt
+++ b/deployments/datahub/images/default/requirements.txt
@@ -37,7 +37,7 @@ seaborn==0.9.0
 bokeh==0.12.6
 decorator==4.4.2
 networkx==2.4
-pygame==1.9.3
+pygame==1.9.6
 nltk==3.4.5
 beautifulsoup4==4.6.0
 spacy==1.9.0

--- a/deployments/datahub/images/default/requirements.txt
+++ b/deployments/datahub/images/default/requirements.txt
@@ -70,7 +70,7 @@ tensorflow==2.1.0
 scikit-image==0.13.1
 Keras==2.0.8
 keras-vis==0.4.1
-tables==3.4.2
+tables==3.6.1
 opencv-python==3.3.0.10
 
 # astr 128/256; spring 2020


### PR DESCRIPTION
Best / only time to make this upgrade.

We also basically move all packages to latest published versions.
Many packages did not have 3.7 compatible wheels - and some just
did not work on 3.7 at all!

This might / will break some users. We should start tracking our
users better so we can inform them beforehand. I'll reach out to some
of the bigger classes to make sure they're aware. 

Hopefully we can do better next semester.