### PR TITLE
datahub: Bump to python 3.8

### DIFF
--- a/deployments/datahub/images/default/environment.yml
+++ b/deployments/datahub/images/default/environment.yml
@@ -1,4 +1,4 @@
 dependencies:
 - nodejs==14.*
 - pip==20.*
-- python==3.7.*
+- python==3.8.*

--- a/deployments/datahub/images/default/requirements.txt
+++ b/deployments/datahub/images/default/requirements.txt
@@ -4,7 +4,7 @@ nbzip==0.0.4
 #
 # data8; foundation
 datascience==0.15.6
-matplotlib==3.1.0
+matplotlib==3.1.3
 pandas==1.1.0
 scipy==1.5.2
 statsmodels==0.11.1

--- a/deployments/datahub/images/default/requirements.txt
+++ b/deployments/datahub/images/default/requirements.txt
@@ -37,7 +37,7 @@ seaborn==0.10.1
 bokeh==2.1.1
 decorator==4.4.2
 networkx==2.4
-pygame==1.9.6
+# pygame==1.9.6
 nltk==3.5
 beautifulsoup4==4.9.1
 spacy==2.3.2


### PR DESCRIPTION
Now that we've bumped up a lot of dependencies to latest,
let's see if this works