### PR TITLE
biology: Set limit to 2G instead of 1G

### DIFF
--- a/deployments/biology/config/common.yaml
+++ b/deployments/biology/config/common.yaml
@@ -38,4 +38,4 @@ jupyterhub:
         subPath: "{username}"
     memory:
       guarantee: 512M
-      limit: 1G
+      limit: 2G


### PR DESCRIPTION
BIO1B might need at least this much RAM