### PR TITLE
Bump up placeholder pods for a lotta hubs

### DIFF
--- a/deployments/data100/config/prod.yaml
+++ b/deployments/data100/config/prod.yaml
@@ -12,4 +12,4 @@ jupyterhub:
   scheduling:
     userPlaceholder:
       enabled: true
-      replicas: 10
+      replicas: 100

--- a/deployments/datahub/config/prod.yaml
+++ b/deployments/datahub/config/prod.yaml
@@ -13,4 +13,4 @@ jupyterhub:
   scheduling:
     userPlaceholder:
       enabled: true
-      replicas: 60
+      replicas: 100

--- a/deployments/eecs/config/prod.yaml
+++ b/deployments/eecs/config/prod.yaml
@@ -13,4 +13,4 @@ jupyterhub:
   scheduling:
     userPlaceholder:
       enabled: true
-      replicas: 30
+      replicas: 60


### PR DESCRIPTION
Start of instruction is today. We can caliberate and reduce
these a week or so later.