### PR TITLE
ci: Prevent merges from prod to staging

### DIFF
--- a/.github/workflows/prevent-prod-merges.yml
+++ b/.github/workflows/prevent-prod-merges.yml
@@ -1,0 +1,13 @@
+name: Prevent prod to staging merges
+
+on:
+  pull_request:
+    branches: staging
+
+jobs:
+  check-branch:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Fail if we are merging prod to staging
+      run: |
+        echo $GITHUB_REF | grep -v prod


### PR DESCRIPTION
Since GitHub prompts you, it is very easy to accidentally
merge the prod branch to staging. This action prevents this,
since there's no way to tell GitHub to not do this :(