### PR TITLE
ci: Print out some env vars for debugging

### DIFF
--- a/.github/workflows/prevent-prod-merges.yml
+++ b/.github/workflows/prevent-prod-merges.yml
@@ -10,4 +10,6 @@ jobs:
     steps:
     - name: Fail if we are merging prod to staging
       run: |
+        env
         echo $GITHUB_REF | grep -v prod
+        cat $GITHUB_EVENT_PATH


### PR DESCRIPTION
We couldn't tell that the branch to be merged was 'prod'
earlier with just $GITHUB_REF - that seems to refer
to the ref specifically for the PR