### PR TITLE
ci: Use $GITHUB_HEAD_REF instead of $GITHUB_REF

### DIFF
--- a/.github/workflows/prevent-prod-merges.yml
+++ b/.github/workflows/prevent-prod-merges.yml
@@ -10,6 +10,4 @@ jobs:
     steps:
     - name: Fail if we are merging prod to staging
       run: |
-        env
-        echo $GITHUB_REF | grep -v prod
-        cat $GITHUB_EVENT_PATH
+        echo $GITHUB_HEAD_REF | grep -v prod


### PR DESCRIPTION
seems to properly refer to the name of branch that
is being merged.