### PR TITLE
Revert "datahub: Increase placeholder pods even more"

### DIFF
--- a/deployments/datahub/config/prod.yaml
+++ b/deployments/datahub/config/prod.yaml
@@ -13,4 +13,4 @@ jupyterhub:
   scheduling:
     userPlaceholder:
       enabled: true
-      replicas: 300
+      replicas: 100


### PR DESCRIPTION
Reverts berkeley-dsep-infra/datahub#1771

I think the placeholders were actually *causing* some of the problems -
see https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/1414.

We had https://github.com/berkeley-dsep-infra/datahub/pull/1050
deployed for some of last year, but I undeployed it since it wasn't
very effective. We might need something like that again?

I've instead made sure there are always at least 8 nodes for the datahub
pool. This should hopefully help instead.

Ref #1746 
