### PR TITLE
datahub: Guarantee it at least 1 full CPU

### DIFF
--- a/deployments/datahub/config/prod.yaml
+++ b/deployments/datahub/config/prod.yaml
@@ -10,6 +10,13 @@ jupyterhub:
       pvc:
         # This also holds logs
         storage: 40Gi
+    resources:
+      requests:
+        # DataHub often takes up a full CPU now, so let's guarantee it at least that
+        cpu: 1
+        memory: 1Gi
+      limits:
+        memory: 2Gi
   scheduling:
     userPlaceholder:
       enabled: true


### PR DESCRIPTION
Our http response times were through the roof,
mostly because of CPU saturation. While we work
on fixing that, this at least makes sure we are guaranteed
one full CPU

Ref #1746