### PR TITLE
hub: Allow incoming traffic from support ns

### DIFF
--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -95,6 +95,11 @@ jupyterhub:
       tag: '0.0.1-n2724.h1dfae31'
     networkPolicy:
       enabled: true
+      ingress:
+      - from:
+        - namespaceSelector:
+            matchLabels:
+              name: support
     resources:
       requests:
         # Very small unit, since we don't want any CPU guarantees


### PR DESCRIPTION
Helps prometheus scrape metrics from hubs, which wasn't
possible until new thanks to our strict networkpolicy

Ref #1746