### PR TITLE
Revert "Revert "Revert "Bump R version to 4.0"""

### DIFF
--- a/deployments/r/image/Dockerfile
+++ b/deployments/r/image/Dockerfile
@@ -1,4 +1,4 @@
-FROM rocker/geospatial:4.0.2
+FROM rocker/geospatial:3.6.0
 
 ENV NB_USER rstudio
 ENV NB_UID 1000

--- a/deployments/r/image/extras.d/ph-142.r
+++ b/deployments/r/image/extras.d/ph-142.r
@@ -16,12 +16,17 @@ class_libs = c(
     "janitor", "1.2.0",
     "latex2exp", "0.4.0",
     "measurements", "1.3.0",
-    "dagitty", "0.2-2",
-    "cowplot", "1.0.0",
-    "rlang", "0.4.7"
+    "dagitty", "0.2-2"
 )
 
 class_libs_install_version(class_name, class_libs)
+
+# not found in CRAN
+print("Installing rlang...")
+devtools::install_github('cran/rlang', ref='0.4.6', upgrade_dependencies=FALSE, quiet=FALSE)
+
+print("Installing patchwork...")
+devtools::install_github('cran/cowplot', ref='1.0.0', upgrade_dependencies=FALSE, quiet=TRUE)
 
 print("Installing patchwork...")
 devtools::install_github('thomasp85/patchwork', ref='36b4918', upgrade_dependencies=FALSE, quiet=TRUE)


### PR DESCRIPTION
Reverts berkeley-dsep-infra/datahub#1774

This breaks RStudio, with the following error message:

<img width="276" alt="Screenshot 2020-09-03 at 6 05 25 PM" src="https://user-images.githubusercontent.com/30430/92115509-296b3280-ee10-11ea-9d2c-5fd9c7000329.png">

There's an iframe with an empty document, and nothing special in the logs.
