### PR TITLE
support: Set prometheus resource requests

### DIFF
--- a/support/values.yaml
+++ b/support/values.yaml
@@ -16,6 +16,10 @@ prometheus:
   rbac:
     create: true
   server:
+    resources:
+      requests:
+        cpu: 1
+        memory: 8Gi
     labels:
       # For HTTP access to the hub, to scrape metrics
       hub.jupyter.org/network-access-hub: 'true'


### PR DESCRIPTION
Otherwise, prometheus ends up on random other nodes,
hogs a lot of CPU and affects performance negatively.

We should set appropriate requests for *all* core pods

Ref #1746