### PR TITLE
datahub: Install cartopy & shapely from source

### DIFF
--- a/deployments/datahub/images/default/requirements.txt
+++ b/deployments/datahub/images/default/requirements.txt
@@ -93,7 +93,8 @@ Theano==1.0.5
 
 # eps 109; fall 2019
 ffmpeg-python==0.2.0
-Cartopy==0.18.0
+# see https://github.com/berkeley-dsep-infra/datahub/issues/1796
+Cartopy==0.18.0 --no-binary Cartopy
 
 # data 88; spring 2020
 plotly==4.9.0
@@ -119,7 +120,8 @@ umap-learn==0.4.6
 hdbscan==0.8.26
 
 # espm 125/bio 105; fall 2019
-shapely==1.7.0
+# see https://github.com/berkeley-dsep-infra/datahub/issues/1796
+shapely==1.7.0 --no-binary shapely
 pyvcf==0.6.8
 bitarray==1.5.2
 nlmpy==0.1.5


### PR DESCRIPTION
So they link against the same version of geos.

We should probably move this to conda-forge at some point?
However, that'll probably bring in a lot of dependencies,
so don't wanna do that right now.

Fixes #1796