### PR TITLE
Add requirements for ds198 mch infodemiology

### DIFF
--- a/deployments/datahub/images/default/requirements.txt
+++ b/deployments/datahub/images/default/requirements.txt
@@ -140,3 +140,10 @@ lcapy==0.66.0
 
 # EPS 256, https://github.com/berkeley-dsep-infra/datahub/issues/1775
 obspy==1.2.2
+
+# ds198 mch infodemiology, fall 2020/spring 2021
+# google apis
+google-api-python-client==1.11.0
+google-auth-httplib2==0.0.4
+google-auth-oauthlib==0.4.1
+google==3.0.0


### PR DESCRIPTION
I am a guest instructor for DS198 MCH Infodemiology and am coordinating the students' technical setup from the Wallace Center team side. 

These requirements are necessary for the Jupyter notebooks we will be distributing to the students.