### PR TITLE
support: Recreate prometheus deployment pods

### DIFF
--- a/support/values.yaml
+++ b/support/values.yaml
@@ -27,6 +27,9 @@ prometheus:
       size: 1000Gi
       storageClass: ssd
     retention: 180d
+    strategy:
+      # Can't really do rolling update, we have a persistent disk attached
+      type: Recreate
     service:
       type: ClusterIP
 


### PR DESCRIPTION
By default, it seems to do a rolling update. With the persistent
disk, that might not always work.