### PR TITLE
Disable user-scheduler

### DIFF
--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -25,7 +25,7 @@ jupyterhub:
       defaultPriority: 0
       userPlaceholderPriority: -10
     userScheduler:
-      enabled: true
+      enabled: false
       resources:
         requests:
           # FIXME: Just unset this?


### PR DESCRIPTION
We are currently packing users tight into nodes. This
is a tradeoff for autoscaling vs cost. However, currently
we are focusing on getting everything as stable as possible,
so there's barely any autoscaling. There's also some reports
of kernels dying from lack of memory, so this will help there
too.

I'll now also collect all logs via stackdriver, so we can
see where the issues are better