### PR TITLE
eecs: Reduce memory requests even more

### DIFF
--- a/deployments/eecs/config/common.yaml
+++ b/deployments/eecs/config/common.yaml
@@ -66,7 +66,7 @@ jupyterhub:
         pvcName: home-nfs
         subPath: "{username}"
     memory:
-      guarantee: 2G
-      limit: 4G
+      guarantee: 512M
+      limit: 2G
     image:
       name: gcr.io/ucb-datahub-2018/eecs-user-image


### PR DESCRIPTION
Looking at actual usage, practically nobody goes over 1G.
However, since linux desktop is still in use here, I'm
leaving limit at 2G instead of 1G.

The drastic reduction in memory requests should help make things
*more* stable by reducing number of autoscaling events
needed.

Memory usage over the last 30 days

<img width="1411" alt="image" src="https://user-images.githubusercontent.com/30430/92645646-c3e0df80-f302-11ea-9a4a-fe1ce728c512.png">

Since start of semester, nobody's really gone over 2G.

I think the 4G users were all the summer course. I'll update the
EECS folks and see what they think.