### PR TITLE
Update to geospatial 3.6.3.

### DIFF
--- a/deployments/r/image/Dockerfile
+++ b/deployments/r/image/Dockerfile
@@ -1,4 +1,4 @@
-FROM rocker/geospatial:3.6.0
+FROM rocker/geospatial:3.6.3
 
 ENV NB_USER rstudio
 ENV NB_UID 1000
@@ -10,6 +10,9 @@ ENV REPO_DIR /srv/repo
 ENV PATH ${CONDA_DIR}/bin:$PATH
 # And set ENV for R! It doesn't read from the environment...
 RUN echo "PATH=${PATH}" >> /usr/local/lib/R/etc/Renviron
+# Use newer MRAN snapshot. The old timestamp corresponds with what is in
+# geospatial:3.6.3.
+RUN sed -i 's/2020-04-24/2020-05-30/' /usr/local/lib/R/etc/Rprofile.site
 
 # Add PATH to /etc/profile so it gets picked up by the terminal
 RUN echo "PATH=${PATH}" >> /etc/profile
@@ -47,7 +50,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Download and install shiny server
-RUN wget --no-verbose https://download3.rstudio.org/ubuntu-14.04/x86_64/shiny-server-1.5.12.933-amd64.deb -O ss.deb && \
+RUN wget --no-verbose https://download3.rstudio.org/ubuntu-14.04/x86_64/shiny-server-1.5.14.948-amd64.deb -O ss.deb && \
     gdebi -n ss.deb && \
     rm -f ss.deb
 RUN chown -R rstudio:rstudio /var/lib/shiny-server

--- a/deployments/r/image/extras.d/2019-fall-stat-131a.r
+++ b/deployments/r/image/extras.d/2019-fall-stat-131a.r
@@ -3,28 +3,30 @@
 source("/tmp/class-libs.R")
 
 class_name = "2019 Fall Stat 131a"
+class_libs_install_version(class_name, c("BiocManager", "1.30.10"))
+BiocManager::install("Biobase", ask = FALSE, update = FALSE)
+
 class_libs = c(
   "alluvial", "0.1-2",
-  "latticeExtra", "0.6-28",
-  "DAAG", "1.22",
+  "latticeExtra", "0.6-29",
+  "DAAG", "1.24",
   "faraway", "1.0.7",
   "fdrtool", "1.2.15",
-  "gpairs", "1.2",
-  "gplots", "3.0.1.1",
-  "hexbin", "1.27.3",
-  "leaps", "2.9",
-  "NMF", "0.21.0",
-  "randomForest", "4.6-12",
+  "gpairs", "1.3.3",
+  "gplots", "3.0.3",
+  "hexbin", "1.28.1",
+  "leaps", "3.1",
+  "NMF", "0.22.0",
+  "randomForest", "4.6-14",
   "RColorBrewer", "1.1-2",
   "rjson", "0.2.20",
-  "rpart.plot", "3.0.7",
+  "rpart.plot", "3.0.8",
   "scatterplot3d", "0.3-41",
   "shape", "1.4.4",
   "sm", "2.2-5.6",
   "pheatmap", "1.0.12"
-  # "vioplot", "0.3.0"
 )
 class_libs_install_version(class_name, class_libs)
 
-# 0.3.0 via mran 2019-07-05
-install.packages('vioplot')
+# 0.3.4; installing in above vector produces an error
+install.packages('vioplot', quiet = TRUE)

--- a/deployments/r/image/extras.d/eep-1118.r
+++ b/deployments/r/image/extras.d/eep-1118.r
@@ -8,7 +8,7 @@ source("/tmp/class-libs.R")
 
 class_name="EEP 1118"
 class_libs = c(
-    "car", "3.0-2"
+    "car", "3.0-8"
 )
 
 class_libs_install_version(class_name, class_libs)

--- a/deployments/r/image/extras.d/example
+++ b/deployments/r/image/extras.d/example
@@ -1,4 +1,9 @@
 #!/usr/bin/env Rscript
 
-# github ref is version 0.8.8
-devtools::install_github('cran/summarytools', ref = '8eeb20a', upgrade_dependencies = FALSE, quiet = TRUE)
+source("/tmp/class-libs.R")
+
+class_name = "Example"
+class_libs = c(
+  "summarytools", "0.9.6"
+)
+class_libs_install_version(class_name, class_libs)

--- a/deployments/r/image/extras.d/ias-c188.r
+++ b/deployments/r/image/extras.d/ias-c188.r
@@ -9,8 +9,8 @@ class_libs = c(
     "rdd", "0.57",
     "stargazer", "5.2.2",
     "lm.beta", "1.5-1",
-    "multcomp", "1.4-8",
-    "lfe", "2.8-2"
+    "multcomp", "1.4-13",
+    "lfe", "2.8-5"
 )
 
 class_libs_install_version(class_name, class_libs)

--- a/deployments/r/image/extras.d/ph-142.r
+++ b/deployments/r/image/extras.d/ph-142.r
@@ -7,34 +7,23 @@ source("/tmp/class-libs.R")
 class_name = "PH142"
 
 class_libs = c(
-    "fGarch", "3042.83.1",
-    "SASxport", "1.6.0",
+    "fGarch", "3042.83.2",
+    "SASxport", "1.7.0",
     "googlesheets", "0.3.0",
-    "googledrive", "0.1.3",
-    "ggrepel", "0.8.1",
-    "infer", "0.4.0.1",
-    "janitor", "1.2.0",
+    "googledrive", "1.0.1",
+    "ggrepel", "0.8.2",
+    "infer", "0.5.1",
+    "janitor", "2.0.1",
     "latex2exp", "0.4.0",
-    "measurements", "1.3.0",
-    "dagitty", "0.2-2"
+    "measurements", "1.4.0",
+    "dagitty", "0.2-2",
+    "rlang", "0.4.6",
+    "cowplot", "1.0.0",
+    "patchwork", "1.0.0",
+    "tigris", "0.9.4",
+    "googlesheets4", "0.2.0"
 )
 
 class_libs_install_version(class_name, class_libs)
-
-# not found in CRAN
-print("Installing rlang...")
-devtools::install_github('cran/rlang', ref='0.4.6', upgrade_dependencies=FALSE, quiet=FALSE)
-
-print("Installing patchwork...")
-devtools::install_github('cran/cowplot', ref='1.0.0', upgrade_dependencies=FALSE, quiet=TRUE)
-
-print("Installing patchwork...")
-devtools::install_github('thomasp85/patchwork', ref='36b4918', upgrade_dependencies=FALSE, quiet=TRUE)
-
-print("Installing tigris...")
-devtools::install_github('walkerke/tigris', ref='78d1e44ccc1f561342078c0e79d0415fa4396389', upgrade_dependencies=FALSE, quiet=TRUE)
-
-print("Installing googlesheets4")
-devtools::install_github("tidyverse/googlesheets4", ref='9348a37511c45257f2aceadf76674a601740e708', upgrade_dependencies=FALSE, quiet=TRUE)
 
 print("Done installing packages for PH142")

--- a/deployments/r/image/extras.d/ph-w250fg.r
+++ b/deployments/r/image/extras.d/ph-w250fg.r
@@ -4,24 +4,21 @@ print("Installing packages for PHW250F+G")
 
 source("/tmp/class-libs.R")
 
-# dplyr requires 0.2.1...cran only has 0.2.0
-print("Installing assertthat...")
-devtools::install_github('hadley/assertthat', ref='v0.2.1', upgrade_dependencies=FALSE, quiet=TRUE)
-
 class_name = "PHW250F+G"
 
 class_libs = c(
+    "assertthat", "0.2.1",
     "here", "0.1",
     "rlist", "0.4.6.1",
-    "jsonlite", "1.6",
+    "jsonlite", "1.6.1",
     "checkr", "0.5.0",
-    "dplyr", "0.8.1",
-    "ggplot2", "3.1.0",
-    "tidyr", "0.8.3"
+    "dplyr", "1.0.0",
+    "tidyr", "1.1.0",
+    "reticulate", "1.16"
 )
 
-# 1.13 isn't found in cran?
-print("Installing reticulate...")
-devtools::install_github('cran/reticulate', ref='1.13', upgrade_dependencies=FALSE, quiet=TRUE)
+# "ggplot2", "3.1.0",
+# ggplot was removed from cran
+# https://cran.microsoft.com/snapshot/2020-05-30/src/contrib/Archive/ggplot/
 
 class_libs_install_version(class_name, class_libs)

--- a/deployments/r/image/extras.d/stat-131a.r
+++ b/deployments/r/image/extras.d/stat-131a.r
@@ -4,7 +4,7 @@ source("/tmp/class-libs.R")
 
 class_name = "Stat 131a"
 class_libs = c(
-    "learnr", "0.9.2"
+    "learnr", "0.10.1"
 )
 
 class_libs_install_version(class_name, class_libs)


### PR DESCRIPTION
This is mostly so we can install dplyr 1.0.0.