### PR TITLE
r: Bump to 4.0, use older RStudio

### DIFF
--- a/deployments/r/image/Dockerfile
+++ b/deployments/r/image/Dockerfile
@@ -1,4 +1,4 @@
-FROM rocker/geospatial:3.6.0
+FROM rocker/geospatial:4.0.2
 
 ENV NB_USER rstudio
 ENV NB_UID 1000
@@ -39,12 +39,22 @@ RUN apt-get update && \
             libgtk-3-0 \
             libnss3 \
             libxss1 \
+            libssl1.1 \
             fonts-symbola \
             tcl8.6-dev \
             tk8.6-dev \
             gdebi-core && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
+
+# Download and install rstudio manually
+# Newer one has bug that doesn't work with jupyter-rsession-proxy
+ENV RSTUDIO_URL https://download2.rstudio.org/server/bionic/amd64/rstudio-server-1.2.5042-amd64.deb
+
+# install rstudio
+RUN curl --silent --location --fail ${RSTUDIO_URL} > /tmp/rstudio.deb && \
+    dpkg -i /tmp/rstudio.deb && \
+    rm /tmp/rstudio.deb
 
 # Download and install shiny server
 RUN wget --no-verbose https://download3.rstudio.org/ubuntu-14.04/x86_64/shiny-server-1.5.12.933-amd64.deb -O ss.deb && \

--- a/deployments/r/image/extras.d/ph-142.r
+++ b/deployments/r/image/extras.d/ph-142.r
@@ -16,17 +16,12 @@ class_libs = c(
     "janitor", "1.2.0",
     "latex2exp", "0.4.0",
     "measurements", "1.3.0",
-    "dagitty", "0.2-2"
+    "dagitty", "0.2-2",
+    "cowplot", "1.0.0",
+    "rlang", "0.4.7"
 )
 
 class_libs_install_version(class_name, class_libs)
-
-# not found in CRAN
-print("Installing rlang...")
-devtools::install_github('cran/rlang', ref='0.4.6', upgrade_dependencies=FALSE, quiet=FALSE)
-
-print("Installing patchwork...")
-devtools::install_github('cran/cowplot', ref='1.0.0', upgrade_dependencies=FALSE, quiet=TRUE)
 
 print("Installing patchwork...")
 devtools::install_github('thomasp85/patchwork', ref='36b4918', upgrade_dependencies=FALSE, quiet=TRUE)


### PR DESCRIPTION
Newer RStudio has issues with jupyter-server-proxy
and won't work yet. But we want newer R, partially so
we can get newer packages. So this gets us there.

See https://github.com/berkeley-dsep-infra/datahub/pull/1666
and the reverts that follow