### PR TITLE
Turn off notebook notary sqlite files

### DIFF
--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -13,6 +13,12 @@ etcJupyter:
       # this is what allows us to shutdown servers
       # when people leave a notebook open and wander off
       cull_connected: true
+    NotebookNotary:
+      # Use memory for notebook notary file to workaround corrupted files on nfs
+      # https://www.sqlite.org/inmemorydb.html
+      # https://github.com/jupyter/jupyter/issues/174
+      # https://github.com/ipython/ipython/issues/9163
+      db_file: ":memory:"
 
 nfsPVC:
   enabled: true


### PR DESCRIPTION
Lots of reports of saving notebooks taking time - sometimes
multiple minutes. We've eliminated a bunch of other options -
network congestion, NFS server resource starvation, node issues,
etc. Let's try this one, based on https://github.com/jupyter/notebook/issues/1888