### PR TITLE
Give the hub container time to startup

### DIFF
--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -110,9 +110,9 @@ jupyterhub:
             - namespaceSelector:
                 matchLabels:
                   name: support
-    readinessProbe:
+    livenessProbe:
       enabled: true
-      initialDelaySeconds: 60
+      initialDelaySeconds: 180
     resources:
       requests:
         # Very small unit, since we don't want any CPU guarantees


### PR DESCRIPTION
The default value for the livenessProbe which is already 60 seconds, so
what's needed is to have an even longer duration than 60 seconds.

Note that the readinessProbe only influence the Ready state of the hub container, which in turn infleunce the k8s Service resource that will only direct traffic to pods with all their containers in a Ready status.

This is a followup to https://github.com/berkeley-dsep-infra/datahub/pull/1871.
