### PR TITLE
Explicitly enable HTTPS

### DIFF
--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -56,6 +56,7 @@ jupyterhub:
         limits:
           memory: 1Gi
     https:
+      enabled: true
       letsencrypt:
         contactEmail: yuvipanda@berkeley.edu
     networkPolicy:


### PR DESCRIPTION
https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/1758
wasn't actually backwards compatible - we need to explicitly
set this now.