### PR TITLE
Enable user scheduler again

### DIFF
--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -31,12 +31,12 @@ jupyterhub:
       defaultPriority: 0
       userPlaceholderPriority: -10
     userScheduler:
-      enabled: false
+      enabled: true
       resources:
         requests:
           # FIXME: Just unset this?
           cpu: 0.01
-          memory: 64Mi
+          memory: 128Mi
         limits:
           memory: 1G
   proxy:


### PR DESCRIPTION
We removed this earlier to reduce possible issues
around outages. We resolved that with work on resource
guarantees for our core pods. Let's bring this back,
so we can slowly scale down our cluster size.