### PR TITLE
Add jupyter-tree-download to all hubs

### DIFF
--- a/deployments/biology/image/infra-requirements.txt
+++ b/deployments/biology/image/infra-requirements.txt
@@ -20,3 +20,4 @@ appmode==0.8.0
 ipywidgets==7.5.1
 notebook-as-pdf==0.3.1
 otter-grader==1.1.3
+jupyter-tree-download==1.0.1

--- a/deployments/data100/image/infra-requirements.txt
+++ b/deployments/data100/image/infra-requirements.txt
@@ -20,3 +20,4 @@ appmode==0.8.0
 ipywidgets==7.5.1
 notebook-as-pdf==0.3.1
 otter-grader==1.1.3
+jupyter-tree-download==1.0.1

--- a/deployments/data102/image/environment.yml
+++ b/deployments/data102/image/environment.yml
@@ -78,7 +78,6 @@ dependencies:
     - plotly_express==0.4.1
     - tweepy==3.8.0
     - ipympl==0.3.3
-    - nbzip==0.1.0
     - jupyter-contrib-nbextensions==0.5.1
     - jassign==0.0.7
     - okpy==1.14.15

--- a/deployments/data102/image/infra-requirements.txt
+++ b/deployments/data102/image/infra-requirements.txt
@@ -20,3 +20,4 @@ appmode==0.8.0
 ipywidgets==7.5.1
 notebook-as-pdf==0.3.1
 otter-grader==1.1.3
+jupyter-tree-download==1.0.1

--- a/deployments/data8x/image/infra-requirements.txt
+++ b/deployments/data8x/image/infra-requirements.txt
@@ -20,3 +20,4 @@ appmode==0.8.0
 ipywidgets==7.5.1
 notebook-as-pdf==0.3.1
 otter-grader==1.1.3
+jupyter-tree-download==1.0.1

--- a/deployments/datahub/images/default/Dockerfile
+++ b/deployments/datahub/images/default/Dockerfile
@@ -231,9 +231,5 @@ RUN jupyter nbextension enable --py --sys-prefix gmaps
 # install QGrid notebook extension
 RUN jupyter nbextension enable --py --sys-prefix qgrid
 
-# Install nbzip
-RUN jupyter serverextension enable  --sys-prefix --py nbzip && \
-    jupyter nbextension     install --sys-prefix --py nbzip && \
-    jupyter nbextension     enable  --sys-prefix --py nbzip
 
 EXPOSE 8888

--- a/deployments/datahub/images/default/infra-requirements.txt
+++ b/deployments/datahub/images/default/infra-requirements.txt
@@ -20,3 +20,4 @@ appmode==0.8.0
 ipywidgets==7.5.1
 notebook-as-pdf==0.3.1
 otter-grader==1.1.3
+jupyter-tree-download==1.0.1

--- a/deployments/datahub/images/default/requirements.txt
+++ b/deployments/datahub/images/default/requirements.txt
@@ -1,4 +1,3 @@
-nbzip==0.0.4
 #
 # data8; foundation
 datascience==0.15.6

--- a/deployments/eecs/image/infra-requirements.txt
+++ b/deployments/eecs/image/infra-requirements.txt
@@ -20,3 +20,4 @@ appmode==0.8.0
 ipywidgets==7.5.1
 notebook-as-pdf==0.3.1
 otter-grader==1.1.3
+jupyter-tree-download==1.0.1

--- a/deployments/highschool/image/infra-requirements.txt
+++ b/deployments/highschool/image/infra-requirements.txt
@@ -20,3 +20,4 @@ appmode==0.8.0
 ipywidgets==7.5.1
 notebook-as-pdf==0.3.1
 otter-grader==1.1.3
+jupyter-tree-download==1.0.1

--- a/deployments/highschool/image/requirements.txt
+++ b/deployments/highschool/image/requirements.txt
@@ -1,6 +1,5 @@
 -r infra-requirements.txt
 
-nbzip==0.0.4
 
 # adding Cython for pandas issue -- https://app.circleci.com/pipelines/github/berkeley-dsep-infra/datahub/905/workflows/7231153f-65ad-4f23-a217-163e8a7de404/jobs/10514/steps
 Cython==0.29.20

--- a/deployments/julia/image/infra-requirements.txt
+++ b/deployments/julia/image/infra-requirements.txt
@@ -20,3 +20,4 @@ appmode==0.8.0
 ipywidgets==7.5.1
 notebook-as-pdf==0.3.1
 otter-grader==1.1.3
+jupyter-tree-download==1.0.1

--- a/deployments/prob140/image/infra-requirements.txt
+++ b/deployments/prob140/image/infra-requirements.txt
@@ -20,3 +20,4 @@ appmode==0.8.0
 ipywidgets==7.5.1
 notebook-as-pdf==0.3.1
 otter-grader==1.1.3
+jupyter-tree-download==1.0.1

--- a/deployments/r/image/infra-requirements.txt
+++ b/deployments/r/image/infra-requirements.txt
@@ -20,3 +20,4 @@ appmode==0.8.0
 ipywidgets==7.5.1
 notebook-as-pdf==0.3.1
 otter-grader==1.1.3
+jupyter-tree-download==1.0.1

--- a/deployments/stat89a/image/infra-requirements.txt
+++ b/deployments/stat89a/image/infra-requirements.txt
@@ -20,3 +20,4 @@ appmode==0.8.0
 ipywidgets==7.5.1
 notebook-as-pdf==0.3.1
 otter-grader==1.1.3
+jupyter-tree-download==1.0.1

--- a/deployments/template/{{cookiecutter.hub_name}}/image/infra-requirements.txt
+++ b/deployments/template/{{cookiecutter.hub_name}}/image/infra-requirements.txt
@@ -20,3 +20,4 @@ appmode==0.8.0
 ipywidgets==7.5.1
 notebook-as-pdf==0.3.1
 otter-grader==1.1.3
+jupyter-tree-download==1.0.1

--- a/scripts/infra-packages/requirements.txt
+++ b/scripts/infra-packages/requirements.txt
@@ -20,3 +20,4 @@ appmode==0.8.0
 ipywidgets==7.5.1
 notebook-as-pdf==0.3.1
 otter-grader==1.1.3
+jupyter-tree-download==1.0.1


### PR DESCRIPTION
Currently some have nbzip, which is deprecated.