### PR TITLE
Delete rstudio state file on startup

### DIFF
--- a/deployments/r/config/common.yaml
+++ b/deployments/r/config/common.yaml
@@ -48,6 +48,18 @@ jupyterhub:
           # List of other admin users
 
   singleuser:
+    initContainers:
+      # Delete rstudio session on startup
+      # See https://github.com/berkeley-dsep-infra/datahub/issues/1899
+      - name: delete-r-session
+        image: busybox
+        command: ["sh", "-c", "rm -rf /home/jovyan/.rstudio"]
+        securityContext:
+          runAsUser: 1000
+        volumeMounts:
+        - name: home
+          mountPath: /home/jovyan
+          subPath: "{username}"
     nodeSelector:
       hub.jupyter.org/pool-name: gamma-pool
     storage:


### PR DESCRIPTION
Seems to be causing a bunch of blocking issues for students,
where they are unable to access the R hub because of possible
corruption in RStudio. Deleting / renaming the state file
seems to do the trick, but doing that on a per-student basis -
especially if they are blocked from using the hub in the meantime -
seems bad.

This might affect classes that rely on persistent R state,
but in general I think that's not a recommended pattern -
preferring state to be in explicitly saved files &
code itself (I could be totally wrong!). We can merge this
to unblock users, and see if others complain about the lack
of state?

Ref #1899


----

#