### PR TITLE
Add packages for PH290W

### DIFF
--- a/deployments/r/image/Dockerfile
+++ b/deployments/r/image/Dockerfile
@@ -109,6 +109,9 @@ RUN Rscript /tmp/extras.d/2020-spring-envecon-c118.r
 COPY --chown=rstudio extras.d/econ-140.r /tmp/extras.d/
 RUN Rscript /tmp/extras.d/econ-140.r
 
+COPY --chown=rstudio extras.d/ph-290.r /tmp/extras.d/
+RUN Rscript /tmp/extras.d/ph-290.r
+
 COPY --chown=rstudio:rstudio . ${REPO_DIR}
 
 RUN pip install --no-cache-dir -r ${REPO_DIR}/requirements.txt

--- a/deployments/r/image/Dockerfile
+++ b/deployments/r/image/Dockerfile
@@ -1,4 +1,5 @@
-FROM rocker/geospatial:4.0.2
+# SHA pin of rocker/geospatial:4.0.2, since rocker tags aren't immutable
+FROM rocker/geospatial@sha256:7b0e833cd52753be619030f61ba9e085b45eb9bb13678311da4a55632c3c8c79
 
 ENV NB_USER rstudio
 ENV NB_UID 1000

--- a/deployments/r/image/extras.d/ph-290.r
+++ b/deployments/r/image/extras.d/ph-290.r
@@ -7,8 +7,8 @@ source("/tmp/class-libs.R")
 class_name = "PH 290W"
 
 class_libs = c(
+  "kableExtra", "1.1.0",
   "plotly", "4.9.2.1",
-  "kableExtra", "1.3.1",
   "ggthemes", "4.2.0",
   "formattable", "0.2.0.1"
 )

--- a/deployments/r/image/extras.d/ph-290.r
+++ b/deployments/r/image/extras.d/ph-290.r
@@ -1,0 +1,16 @@
+#!/usr/bin/env Rscript
+# For https://github.com/berkeley-dsep-infra/datahub/issues/1921
+print("Installing packages for PH 290W")
+
+source("/tmp/class-libs.R")
+
+class_name = "PH 290W"
+
+class_libs = c(
+  "plotly", "4.9.2.1",
+  "kableExtra", "1.3.1",
+  "ggthemes", "4.2.0",
+  "formattable", "0.2.0.1"
+)
+
+class_libs_install_version(class_name, class_libs)


### PR DESCRIPTION
We get version `1.1.0` of `kableExtra`, since our base image (rocker/geospatial) pins
CRAN using snapshots. If you run `getOption("repos")`, you'll get something like:

```
> getOption("repos")
                                                        CRAN 
"https://packagemanager.rstudio.com/all/__linux__/focal/344"
```

Based on fudging around with dates in https://packagemanager.rstudio.com/client/#/repos/1/overview,
I could see that `344` points to October 13. `kableExtra` 1.3.0 and 1.3.1 were published October 22 and later,
so they aren't present in that snapshot!

So an earlier version of kableExtra works fine. 

R packaging is fun :)


Fixes #1921