### PR TITLE
docs: Update node-pool cluster creation command

### DIFF
--- a/docs/admins/cluster-config.rst
+++ b/docs/admins/cluster-config.rst
@@ -45,8 +45,8 @@ the currently favored configuration.
 .. code:: bash
 
     gcloud container node-pools create  \
-        --machine-type e2-highmem-8 \
-        --num-nodes 1 \
+        --machine-type n1-highmem-8 \
+        --num-nodes 2 \
         --enable-autoscaling \
         --min-nodes 1 --max-nodes 20 \
         --node-labels hub.jupyter.org/pool-name=<pool-name>-pool \
@@ -56,7 +56,7 @@ the currently favored configuration.
         --disk-size=200 --disk-type=pd-ssd \
         --no-enable-autoupgrade \
         --tags=hub-cluster \
-        --cluster=<cluster-name> \
+        --cluster=fall-2019 \
         user-pool-<pool-name>-<yyyy>-<mm>-<dd>
 
 


### PR DESCRIPTION
e2 instances don't have sustained use discount, only
committed use discount. Our load is too variable to depend
on committed use discounts for the cheaper prices. So we
move back to n1 nodes.

Our e2 committments will continue to be consumed by our
core nodepools. But once they run out, we should probably
switch those over to n1 as well - the complexity isn't
worth it for us maybe. Let's make that decision then.

Ref #1354