### PR TITLE
Upgrade nbresuse to use new endpoint

### DIFF
--- a/deployments/biology/image/infra-requirements.txt
+++ b/deployments/biology/image/infra-requirements.txt
@@ -14,7 +14,8 @@ nbconvert==5.6.1
 nbformat==5.0.7
 jupyterlab==2.2.4
 nbgitpuller==0.9.0
-nbresuse==0.3.6
+# Temporary fix until https://github.com/yuvipanda/nbresuse/pull/68/commits/87c306f7a604e866e83c6b1f6d4cc8b4015143c6 is merged
+git+https://github.com/yuvipanda/nbresuse.git@87c306f7a604e866e83c6b1f6d4cc8b4015143c6
 jupyterhub==1.1.0
 appmode==0.8.0
 ipywidgets==7.5.1

--- a/deployments/data100/image/infra-requirements.txt
+++ b/deployments/data100/image/infra-requirements.txt
@@ -14,7 +14,8 @@ nbconvert==5.6.1
 nbformat==5.0.7
 jupyterlab==2.2.4
 nbgitpuller==0.9.0
-nbresuse==0.3.6
+# Temporary fix until https://github.com/yuvipanda/nbresuse/pull/68/commits/87c306f7a604e866e83c6b1f6d4cc8b4015143c6 is merged
+git+https://github.com/yuvipanda/nbresuse.git@87c306f7a604e866e83c6b1f6d4cc8b4015143c6
 jupyterhub==1.1.0
 appmode==0.8.0
 ipywidgets==7.5.1

--- a/deployments/data102/image/infra-requirements.txt
+++ b/deployments/data102/image/infra-requirements.txt
@@ -14,7 +14,8 @@ nbconvert==5.6.1
 nbformat==5.0.7
 jupyterlab==2.2.4
 nbgitpuller==0.9.0
-nbresuse==0.3.6
+# Temporary fix until https://github.com/yuvipanda/nbresuse/pull/68/commits/87c306f7a604e866e83c6b1f6d4cc8b4015143c6 is merged
+git+https://github.com/yuvipanda/nbresuse.git@87c306f7a604e866e83c6b1f6d4cc8b4015143c6
 jupyterhub==1.1.0
 appmode==0.8.0
 ipywidgets==7.5.1

--- a/deployments/data8x/image/infra-requirements.txt
+++ b/deployments/data8x/image/infra-requirements.txt
@@ -14,7 +14,8 @@ nbconvert==5.6.1
 nbformat==5.0.7
 jupyterlab==2.2.4
 nbgitpuller==0.9.0
-nbresuse==0.3.6
+# Temporary fix until https://github.com/yuvipanda/nbresuse/pull/68/commits/87c306f7a604e866e83c6b1f6d4cc8b4015143c6 is merged
+git+https://github.com/yuvipanda/nbresuse.git@87c306f7a604e866e83c6b1f6d4cc8b4015143c6
 jupyterhub==1.1.0
 appmode==0.8.0
 ipywidgets==7.5.1

--- a/deployments/datahub/images/default/infra-requirements.txt
+++ b/deployments/datahub/images/default/infra-requirements.txt
@@ -14,7 +14,8 @@ nbconvert==5.6.1
 nbformat==5.0.7
 jupyterlab==2.2.4
 nbgitpuller==0.9.0
-nbresuse==0.3.6
+# Temporary fix until https://github.com/yuvipanda/nbresuse/pull/68/commits/87c306f7a604e866e83c6b1f6d4cc8b4015143c6 is merged
+git+https://github.com/yuvipanda/nbresuse.git@87c306f7a604e866e83c6b1f6d4cc8b4015143c6
 jupyterhub==1.1.0
 appmode==0.8.0
 ipywidgets==7.5.1

--- a/deployments/eecs/image/infra-requirements.txt
+++ b/deployments/eecs/image/infra-requirements.txt
@@ -14,7 +14,8 @@ nbconvert==5.6.1
 nbformat==5.0.7
 jupyterlab==2.2.4
 nbgitpuller==0.9.0
-nbresuse==0.3.6
+# Temporary fix until https://github.com/yuvipanda/nbresuse/pull/68/commits/87c306f7a604e866e83c6b1f6d4cc8b4015143c6 is merged
+git+https://github.com/yuvipanda/nbresuse.git@87c306f7a604e866e83c6b1f6d4cc8b4015143c6
 jupyterhub==1.1.0
 appmode==0.8.0
 ipywidgets==7.5.1

--- a/deployments/highschool/image/infra-requirements.txt
+++ b/deployments/highschool/image/infra-requirements.txt
@@ -14,7 +14,8 @@ nbconvert==5.6.1
 nbformat==5.0.7
 jupyterlab==2.2.4
 nbgitpuller==0.9.0
-nbresuse==0.3.6
+# Temporary fix until https://github.com/yuvipanda/nbresuse/pull/68/commits/87c306f7a604e866e83c6b1f6d4cc8b4015143c6 is merged
+git+https://github.com/yuvipanda/nbresuse.git@87c306f7a604e866e83c6b1f6d4cc8b4015143c6
 jupyterhub==1.1.0
 appmode==0.8.0
 ipywidgets==7.5.1

--- a/deployments/julia/image/infra-requirements.txt
+++ b/deployments/julia/image/infra-requirements.txt
@@ -14,7 +14,8 @@ nbconvert==5.6.1
 nbformat==5.0.7
 jupyterlab==2.2.4
 nbgitpuller==0.9.0
-nbresuse==0.3.6
+# Temporary fix until https://github.com/yuvipanda/nbresuse/pull/68/commits/87c306f7a604e866e83c6b1f6d4cc8b4015143c6 is merged
+git+https://github.com/yuvipanda/nbresuse.git@87c306f7a604e866e83c6b1f6d4cc8b4015143c6
 jupyterhub==1.1.0
 appmode==0.8.0
 ipywidgets==7.5.1

--- a/deployments/prob140/image/infra-requirements.txt
+++ b/deployments/prob140/image/infra-requirements.txt
@@ -14,7 +14,8 @@ nbconvert==5.6.1
 nbformat==5.0.7
 jupyterlab==2.2.4
 nbgitpuller==0.9.0
-nbresuse==0.3.6
+# Temporary fix until https://github.com/yuvipanda/nbresuse/pull/68/commits/87c306f7a604e866e83c6b1f6d4cc8b4015143c6 is merged
+git+https://github.com/yuvipanda/nbresuse.git@87c306f7a604e866e83c6b1f6d4cc8b4015143c6
 jupyterhub==1.1.0
 appmode==0.8.0
 ipywidgets==7.5.1

--- a/deployments/r/image/infra-requirements.txt
+++ b/deployments/r/image/infra-requirements.txt
@@ -14,7 +14,8 @@ nbconvert==5.6.1
 nbformat==5.0.7
 jupyterlab==2.2.4
 nbgitpuller==0.9.0
-nbresuse==0.3.6
+# Temporary fix until https://github.com/yuvipanda/nbresuse/pull/68/commits/87c306f7a604e866e83c6b1f6d4cc8b4015143c6 is merged
+git+https://github.com/yuvipanda/nbresuse.git@87c306f7a604e866e83c6b1f6d4cc8b4015143c6
 jupyterhub==1.1.0
 appmode==0.8.0
 ipywidgets==7.5.1

--- a/deployments/stat89a/image/infra-requirements.txt
+++ b/deployments/stat89a/image/infra-requirements.txt
@@ -14,7 +14,8 @@ nbconvert==5.6.1
 nbformat==5.0.7
 jupyterlab==2.2.4
 nbgitpuller==0.9.0
-nbresuse==0.3.6
+# Temporary fix until https://github.com/yuvipanda/nbresuse/pull/68/commits/87c306f7a604e866e83c6b1f6d4cc8b4015143c6 is merged
+git+https://github.com/yuvipanda/nbresuse.git@87c306f7a604e866e83c6b1f6d4cc8b4015143c6
 jupyterhub==1.1.0
 appmode==0.8.0
 ipywidgets==7.5.1

--- a/deployments/template/{{cookiecutter.hub_name}}/image/infra-requirements.txt
+++ b/deployments/template/{{cookiecutter.hub_name}}/image/infra-requirements.txt
@@ -14,7 +14,8 @@ nbconvert==5.6.1
 nbformat==5.0.7
 jupyterlab==2.2.4
 nbgitpuller==0.9.0
-nbresuse==0.3.6
+# Temporary fix until https://github.com/yuvipanda/nbresuse/pull/68/commits/87c306f7a604e866e83c6b1f6d4cc8b4015143c6 is merged
+git+https://github.com/yuvipanda/nbresuse.git@87c306f7a604e866e83c6b1f6d4cc8b4015143c6
 jupyterhub==1.1.0
 appmode==0.8.0
 ipywidgets==7.5.1

--- a/scripts/infra-packages/requirements.txt
+++ b/scripts/infra-packages/requirements.txt
@@ -14,7 +14,8 @@ nbconvert==5.6.1
 nbformat==5.0.7
 jupyterlab==2.2.4
 nbgitpuller==0.9.0
-nbresuse==0.3.6
+# Temporary fix until https://github.com/yuvipanda/nbresuse/pull/68/commits/87c306f7a604e866e83c6b1f6d4cc8b4015143c6 is merged
+git+https://github.com/yuvipanda/nbresuse.git@87c306f7a604e866e83c6b1f6d4cc8b4015143c6
 jupyterhub==1.1.0
 appmode==0.8.0
 ipywidgets==7.5.1


### PR DESCRIPTION
Brings in https://github.com/yuvipanda/nbresuse/pull/68 so
we can move towards getting prometheus metrics from notebooks.