### PR TITLE
Upgrade repo2docker to get julia image to build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,9 +33,10 @@ orbs:
                 python3 -m venv venv
                 source venv/bin/activate
                 pip install --upgrade -r requirements.txt
-                # Install repo2docker master to fix offline-notebook
+                # Install repo2docker master to fix offline-notebook and julia
                 # See https://github.com/berkeley-dsep-infra/datahub/pull/1937
-                pip install --upgrade git+https://github.com/jupyter/repo2docker.git@30ef2209cc767826e2647886854fac12469a06c1
+                # See https://github.com/jupyterhub/repo2docker/pull/975
+                pip install --upgrade git+https://github.com/jupyter/repo2docker.git@968cc43a9e238916b5032edbf84e309c8d4ff35e
                 echo 'export PATH="${HOME}/repo/venv/bin:$PATH"' >> ${BASH_ENV}
 
           - unless:
@@ -116,8 +117,9 @@ jobs:
             python3 -m venv venv
             source venv/bin/activate
             pip install --upgrade -r requirements.txt
-            # Install latest repo2docker to get https://github.com/jupyter/repo2docker/pull/859
-            pip install --upgrade git+https://github.com/jupyter/repo2docker@bbc3ee02c0755b15ea456f9ae18dd76b904568e7
+
+            # Keep same repo2docker version in build & deploy jobs
+            pip install --upgrade git+https://github.com/jupyter/repo2docker.git@968cc43a9e238916b5032edbf84e309c8d4ff35e
 
             # Can be removed once https://github.com/docker/docker-py/issues/2225 is merged and released
             pip install --upgrade git+https://github.com/docker/docker-py.git@b6f6e7270ef1acfe7398b99b575d22d0d37ae8bf


### PR DESCRIPTION
https://app.circleci.com/pipelines/github/berkeley-dsep-infra/datahub/1509/workflows/5c9ebf4d-bcb7-4f87-9786-b4534175c8dc/jobs/17172
reports the following error when trying to build julia image:

```
Step 47/63 : RUN chown ${NB_USER}:${NB_USER} ${REPO_DIR}
 ---> Running in b9d6d39bca17
chown: changing ownership of '/srv/repo': Operation not permitted
```

I suspect this is fixed with
https://github.com/jupyterhub/repo2docker/pull/975,
so we upgrade repo2docker in CircleCI to see if that works.