### PR TITLE
Disable metrics ingestion from User servers

### DIFF
--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -127,7 +127,7 @@ jupyterhub:
     startTimeout: 600 # 10 mins, because sometimes we have too many new nodes coming up together
     defaultUrl: /tree
     extraAnnotations:
-      prometheus.io/scrape: "true"
+      prometheus.io/scrape: "false"
       prometheus.io/path: "/user/{username}/metrics"
       prometheus.io/port: "8888"
     networkPolicy:


### PR DESCRIPTION
So many metrics, it has totally crashed the prometheus
server - just IO Timeouts!