### PR TITLE
Upgrade datahub & data100 images to focal

### DIFF
--- a/deployments/biology/image/infra-requirements.txt
+++ b/deployments/biology/image/infra-requirements.txt
@@ -8,18 +8,13 @@
 # everwhere one by one.
 
 # FIXME: Freeze this to get exact versions of all dependencies
-# FIXME: Automate finding out when there are new versions of these
-# Temporary until https://github.com/jupyter/notebook/pull/5870 is released
-git+https://github.com/jupyter/notebook@5a73a8e4026ccc8d7437f788bf0bc2758a73567d
-nbconvert==5.6.1
-nbformat==5.0.7
-jupyterlab==2.2.4
+notebook==6.1.6
+jupyterlab==2.2.9
 nbgitpuller==0.9.0
-# Temporary fix until https://github.com/yuvipanda/nbresuse/pull/68/commits/87c306f7a604e866e83c6b1f6d4cc8b4015143c6 is merged
-git+https://github.com/yuvipanda/nbresuse.git@87c306f7a604e866e83c6b1f6d4cc8b4015143c6
-jupyterhub==1.1.0
+jupyter-resource-usage==0.5.1
+jupyterhub==1.3.0
 appmode==0.8.0
-ipywidgets==7.5.1
+ipywidgets==7.6.3
 notebook-as-pdf==0.3.1
 otter-grader==1.1.3
 jupyter-tree-download==1.0.1

--- a/deployments/data100/image/Dockerfile
+++ b/deployments/data100/image/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps:bionic-scm
+FROM buildpack-deps:focal-scm
 
 # Set up common env variables
 ENV TZ=America/Los_Angeles
@@ -50,13 +50,10 @@ RUN apt-get update -qq --yes && \
         pandoc \
         texlive-xetex \
         texlive-fonts-recommended \
-        texlive-generic-recommended \
+        texlive-plain-generic \
         > /dev/null
 
 WORKDIR /home/jovyan
-
-# prevent bibtex from interupting nbconvert
-RUN update-alternatives --install /usr/bin/bibtex bibtex /bin/true 200
 
 COPY install-miniforge.bash /tmp/install-miniforge.bash
 RUN /tmp/install-miniforge.bash

--- a/deployments/data100/image/infra-requirements.txt
+++ b/deployments/data100/image/infra-requirements.txt
@@ -8,18 +8,13 @@
 # everwhere one by one.
 
 # FIXME: Freeze this to get exact versions of all dependencies
-# FIXME: Automate finding out when there are new versions of these
-# Temporary until https://github.com/jupyter/notebook/pull/5870 is released
-git+https://github.com/jupyter/notebook@5a73a8e4026ccc8d7437f788bf0bc2758a73567d
-nbconvert==5.6.1
-nbformat==5.0.7
-jupyterlab==2.2.4
+notebook==6.1.6
+jupyterlab==2.2.9
 nbgitpuller==0.9.0
-# Temporary fix until https://github.com/yuvipanda/nbresuse/pull/68/commits/87c306f7a604e866e83c6b1f6d4cc8b4015143c6 is merged
-git+https://github.com/yuvipanda/nbresuse.git@87c306f7a604e866e83c6b1f6d4cc8b4015143c6
-jupyterhub==1.1.0
+jupyter-resource-usage==0.5.1
+jupyterhub==1.3.0
 appmode==0.8.0
-ipywidgets==7.5.1
+ipywidgets==7.6.3
 notebook-as-pdf==0.3.1
 otter-grader==1.1.3
 jupyter-tree-download==1.0.1

--- a/deployments/data102/image/infra-requirements.txt
+++ b/deployments/data102/image/infra-requirements.txt
@@ -8,18 +8,13 @@
 # everwhere one by one.
 
 # FIXME: Freeze this to get exact versions of all dependencies
-# FIXME: Automate finding out when there are new versions of these
-# Temporary until https://github.com/jupyter/notebook/pull/5870 is released
-git+https://github.com/jupyter/notebook@5a73a8e4026ccc8d7437f788bf0bc2758a73567d
-nbconvert==5.6.1
-nbformat==5.0.7
-jupyterlab==2.2.4
+notebook==6.1.6
+jupyterlab==2.2.9
 nbgitpuller==0.9.0
-# Temporary fix until https://github.com/yuvipanda/nbresuse/pull/68/commits/87c306f7a604e866e83c6b1f6d4cc8b4015143c6 is merged
-git+https://github.com/yuvipanda/nbresuse.git@87c306f7a604e866e83c6b1f6d4cc8b4015143c6
-jupyterhub==1.1.0
+jupyter-resource-usage==0.5.1
+jupyterhub==1.3.0
 appmode==0.8.0
-ipywidgets==7.5.1
+ipywidgets==7.6.3
 notebook-as-pdf==0.3.1
 otter-grader==1.1.3
 jupyter-tree-download==1.0.1

--- a/deployments/data8x/image/infra-requirements.txt
+++ b/deployments/data8x/image/infra-requirements.txt
@@ -8,18 +8,13 @@
 # everwhere one by one.
 
 # FIXME: Freeze this to get exact versions of all dependencies
-# FIXME: Automate finding out when there are new versions of these
-# Temporary until https://github.com/jupyter/notebook/pull/5870 is released
-git+https://github.com/jupyter/notebook@5a73a8e4026ccc8d7437f788bf0bc2758a73567d
-nbconvert==5.6.1
-nbformat==5.0.7
-jupyterlab==2.2.4
+notebook==6.1.6
+jupyterlab==2.2.9
 nbgitpuller==0.9.0
-# Temporary fix until https://github.com/yuvipanda/nbresuse/pull/68/commits/87c306f7a604e866e83c6b1f6d4cc8b4015143c6 is merged
-git+https://github.com/yuvipanda/nbresuse.git@87c306f7a604e866e83c6b1f6d4cc8b4015143c6
-jupyterhub==1.1.0
+jupyter-resource-usage==0.5.1
+jupyterhub==1.3.0
 appmode==0.8.0
-ipywidgets==7.5.1
+ipywidgets==7.6.3
 notebook-as-pdf==0.3.1
 otter-grader==1.1.3
 jupyter-tree-download==1.0.1

--- a/deployments/datahub/images/default/Dockerfile
+++ b/deployments/datahub/images/default/Dockerfile
@@ -145,10 +145,9 @@ RUN pip install --no-cache -r /tmp/infra-requirements.txt
 # like https://app.circleci.com/pipelines/github/berkeley-dsep-infra/datahub/1176/workflows/7f49851f-c2fc-46ca-b887-15d8e5612097/jobs/13584
 RUN jlpm cache dir && mkdir -p /tmp/yarncache && \
     jlpm config set cache-folder /tmp/yarncache && \
-    jupyter labextension install --debug \
+    jupyter labextension install \
             @jupyter-widgets/jupyterlab-manager \
             jupyter-matplotlib \
-            jupyterlab-plotly \
             @jupyterlab/geojson-extension \
             jupyterlab-videochat@0.4 \
             ipycanvas  && \

--- a/deployments/datahub/images/default/Dockerfile
+++ b/deployments/datahub/images/default/Dockerfile
@@ -147,7 +147,6 @@ RUN jlpm cache dir && mkdir -p /tmp/yarncache && \
     jlpm config set cache-folder /tmp/yarncache && \
     jupyter labextension install --debug \
             @jupyter-widgets/jupyterlab-manager \
-            jupyter-matplotlib \
             jupyterlab-plotly \
             @jupyterlab/geojson-extension \
             jupyterlab-videochat@0.4 \

--- a/deployments/datahub/images/default/Dockerfile
+++ b/deployments/datahub/images/default/Dockerfile
@@ -90,10 +90,9 @@ RUN apt-get update -qq --yes && \
         lsb-release \
         libclang-dev  > /dev/null
             
-# Set path where R packages are installed
-# Download and install rstudio manually
-# Newer one has bug that doesn't work with jupyter-rsession-proxy
-ENV RSTUDIO_URL https://download2.rstudio.org/server/bionic/amd64/rstudio-server-1.2.5042-amd64.deb
+# 1.3.959 is latest version that works with jupyter-rsession-proxy
+# See https://github.com/jupyterhub/jupyter-rsession-proxy/issues/93#issuecomment-725874693
+ENV RSTUDIO_URL https://download2.rstudio.org/server/bionic/amd64/rstudio-server-1.3.959-amd64.deb
 RUN curl --silent --location --fail ${RSTUDIO_URL} > /tmp/rstudio.deb && \
     dpkg -i /tmp/rstudio.deb && \
     rm /tmp/rstudio.deb

--- a/deployments/datahub/images/default/Dockerfile
+++ b/deployments/datahub/images/default/Dockerfile
@@ -145,7 +145,7 @@ RUN pip install --no-cache -r /tmp/infra-requirements.txt
 # like https://app.circleci.com/pipelines/github/berkeley-dsep-infra/datahub/1176/workflows/7f49851f-c2fc-46ca-b887-15d8e5612097/jobs/13584
 RUN jlpm cache dir && mkdir -p /tmp/yarncache && \
     jlpm config set cache-folder /tmp/yarncache && \
-    jupyter labextension install \
+    jupyter labextension install --debug \
             @jupyter-widgets/jupyterlab-manager \
             jupyter-matplotlib \
             @jupyterlab/geojson-extension \

--- a/deployments/datahub/images/default/Dockerfile
+++ b/deployments/datahub/images/default/Dockerfile
@@ -147,6 +147,7 @@ RUN jlpm cache dir && mkdir -p /tmp/yarncache && \
     jlpm config set cache-folder /tmp/yarncache && \
     jupyter labextension install --debug \
             @jupyter-widgets/jupyterlab-manager \
+            jupyter-matplotlib \
             jupyterlab-plotly \
             @jupyterlab/geojson-extension \
             jupyterlab-videochat@0.4 \

--- a/deployments/datahub/images/default/Dockerfile
+++ b/deployments/datahub/images/default/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps:bionic-scm
+FROM buildpack-deps:focal-scm
 
 ENV CONDA_DIR /opt/conda
 
@@ -13,7 +13,13 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV NB_USER jovyan
 ENV NB_UID 1000
 
+
 RUN adduser --disabled-password --gecos "Default Jupyter user" ${NB_USER}
+
+# Create user owned R libs dir
+# This lets users temporarily install packages
+ENV R_LIBS_USER /opt/r
+RUN mkdir -p ${R_LIBS_USER} && chown ${NB_USER}:${NB_USER} ${R_LIBS_USER}
 
 RUN apt-get -qq update --yes && \
     apt-get -qq install --yes \
@@ -25,131 +31,29 @@ RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && \
     locale-gen
 
 # for nbconvert
+# FIXME: Understand what exactly we want
+# texlive-plain-generic is new name of texlive-generic-recommended
 RUN apt-get -qq install --yes \
             pandoc \
             texlive-xetex \
             texlive-fonts-recommended \
-            texlive-generic-recommended > /dev/null
+            texlive-plain-generic > /dev/null
 
 RUN apt-get -qq install --yes \
             # for LS88-5 and modules basemap
             libspatialindex-dev \
+            # for cartopy
             libgeos-dev \
+            libproj-dev \
+            proj-data \
+            proj-bin \
+            # For L&S22
+            graphviz \
             # for phys 151
             gfortran \
             # for eps 109; fall 2019
             ffmpeg > /dev/null
 
-# install R, packages, and RStudio dependencies
-RUN apt-get -qq update --yes && \
-    apt-get -qq install --yes \
-            libapparmor1 \
-            libgdal-dev \
-            libproj-dev \
-            psmisc \
-            sudo \
-            r-base \
-            r-base-dev \
-            r-cran-aer \
-            r-cran-backports \
-            r-cran-base64enc \
-            r-cran-bindrcpp \
-            r-cran-broom \
-            r-cran-crayon \
-            r-cran-crosstalk \
-            r-cran-curl \
-            r-cran-data.table \
-            r-cran-dbi \
-            r-cran-devtools \
-            r-cran-digest \
-            r-cran-e1071 \
-            r-cran-evaluate \
-            r-cran-forcats \
-            r-cran-ggplot2 \
-            r-cran-glue \
-            r-cran-haven \
-            r-cran-highr \
-            r-cran-hms \
-            r-cran-htmlwidgets \
-            r-cran-httpuv \
-            r-cran-httr \
-            r-cran-lubridate \
-            r-cran-mapproj \
-            r-cran-maptools \
-            r-cran-markdown \
-            r-cran-matrix \
-            r-cran-matrixstats \
-            r-cran-memoise \
-            r-cran-nlme \
-            r-cran-openssl \
-            r-cran-pbdzmq \
-            r-cran-pillar \
-            r-cran-png \
-            r-cran-praise \
-            r-cran-proto \
-            r-cran-raster \
-            r-cran-rcolorbrewer \
-            r-cran-rcpp \
-            r-cran-rcurl \
-            r-cran-readr \
-            r-cran-readxl \
-            r-cran-rematch \
-            r-cran-repr \
-            r-cran-reshape \
-            r-cran-rjson \
-            r-cran-rlang \
-            r-cran-rpart \
-            r-cran-rprojroot \
-            r-cran-shiny \
-            r-cran-sp \
-            r-cran-spatstat \
-            r-cran-spdep \
-            r-cran-stringr \
-            r-cran-stringi \
-            r-cran-testthat \
-            r-cran-tibble \
-            r-cran-tidyr \
-            r-cran-utf8 \
-            r-cran-uuid \
-            r-cran-viridis \
-            r-cran-withr \
-            r-cran-xml2 \
-            r-cran-yaml \
-            r-cran-rlist \
-            r-cran-jsonlite \
-            r-cran-assertthat \
-            lsb-release > /dev/null
-            
-# install graphviz
-RUN apt-get -qq update --yes && \
-    apt-get -qq install --yes graphviz
-
-# Install some R libraries that aren't in the debs
-COPY install.R  /tmp/install.R
-# CircleCI stops printing output at 40k chars.
-# We send stdout to a log file, and tail it a bit
-# FIXME: Find something less sucky
-# another hubploy #1
-RUN Rscript /tmp/install.R > /tmp/r-custom-packages.log 2>&1 && \
-    true || ( echo FAIL ; tail /tmp/r-custom-packages.log ; false )
-RUN tail /tmp/r-custom-packages.log
-RUN rm /tmp/r-custom-packages.log
-
-ENV RSTUDIO_URL https://download2.rstudio.org/rstudio-server-1.1.453-amd64.deb
-ENV RSTUDIO_CHECKSUM 3c546fa9067f48ed1a342f810fca8be6
-
-# install rstudio
-RUN curl --silent --location --fail ${RSTUDIO_URL} > /tmp/rstudio.deb && \
-    echo "${RSTUDIO_CHECKSUM} /tmp/rstudio.deb" | md5sum -c - && \
-    dpkg -i /tmp/rstudio.deb && \
-    rm /tmp/rstudio.deb
-
-ENV PATH ${CONDA_DIR}/bin:$PATH:/usr/lib/rstudio-server/bin
-
-# Set this to be on container storage, rather than under $HOME
-ENV IPYTHONDIR ${CONDA_DIR}/etc/ipython
-
-# FIXME: Move this elsewhere in the dockerfile?
 # Install packages needed by notebook-as-pdf
 # Default fonts seem ok, we just install an emoji font
 RUN apt-get update && \
@@ -164,9 +68,59 @@ RUN apt-get update && \
             libgtk-3-0 \
             libnss3 \
             libxss1 \
-            fonts-noto-color-emoji && \
+            fonts-noto-color-emoji > /dev/null && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
+
+
+# Install R packages
+RUN apt-get update -qq --yes > /dev/null && \
+    apt-get install --yes -qq \
+    r-base \
+    r-base-dev \
+    r-recommended \
+    r-cran-littler  > /dev/null
+
+# Needed by RStudio
+RUN apt-get update -qq --yes && \
+    apt-get install --yes --no-install-recommends -qq \
+        psmisc \
+        sudo \
+        libapparmor1 \
+        lsb-release \
+        libclang-dev  > /dev/null
+            
+# Set path where R packages are installed
+# Download and install rstudio manually
+# Newer one has bug that doesn't work with jupyter-rsession-proxy
+ENV RSTUDIO_URL https://download2.rstudio.org/server/bionic/amd64/rstudio-server-1.2.5042-amd64.deb
+RUN curl --silent --location --fail ${RSTUDIO_URL} > /tmp/rstudio.deb && \
+    dpkg -i /tmp/rstudio.deb && \
+    rm /tmp/rstudio.deb
+
+# Set CRAN mirror to rspm before we install anything
+COPY Rprofile.site /usr/lib/R/etc/Rprofile.site
+# RStudio needs its own config
+COPY rsession.conf /etc/rstudio/rsession.conf
+
+# R_LIBS_USER is set by default in /etc/R/Renviron, which RStudio loads.
+# We uncomment the default, and set what we wanna - so it picks up
+# the packages we install. Without this, RStudio doesn't see the packages
+# that R does.
+# Stolen from https://github.com/jupyterhub/repo2docker/blob/6a07a48b2df48168685bb0f993d2a12bd86e23bf/repo2docker/buildpacks/r.py
+RUN sed -i -e '/^R_LIBS_USER=/s/^/#/' /etc/R/Renviron && \
+    echo "R_LIBS_USER=${R_LIBS_USER}" >> /etc/R/Renviron
+
+# Install all our base R packages
+COPY install.R  /tmp/install.R
+RUN /tmp/install.R && \
+    rm -rf /tmp/downloaded_packages
+
+ENV PATH ${CONDA_DIR}/bin:$PATH:/usr/lib/rstudio-server/bin
+
+# Set this to be on container storage, rather than under $HOME
+ENV IPYTHONDIR ${CONDA_DIR}/etc/ipython
+
 
 WORKDIR /home/${NB_USER}
 
@@ -202,13 +156,16 @@ RUN jlpm cache dir && mkdir -p /tmp/yarncache && \
     rm -rf /tmp/yarncache
 
 RUN pip install --no-cache numpy==1.18.5 cython==0.29.21
+
+
 RUN pip install --no-cache -r /tmp/requirements.txt
+
 # Set up nbpdf dependencies
 ENV PYPPETEER_HOME ${CONDA_DIR}
 RUN pyppeteer-install
 
 # Install IR kernelspec
-RUN Rscript -e "IRkernel::installspec(user = FALSE, prefix='${CONDA_DIR}')"
+RUN r -e "IRkernel::installspec(user = FALSE, prefix='${CONDA_DIR}')"
 
 COPY d8extension.bash /usr/local/sbin/d8extension.bash
 RUN /usr/local/sbin/d8extension.bash

--- a/deployments/datahub/images/default/Dockerfile
+++ b/deployments/datahub/images/default/Dockerfile
@@ -129,12 +129,10 @@ RUN /tmp/install-miniforge.bash
 USER ${NB_USER}
 
 COPY environment.yml /tmp/environment.yml
-COPY requirements.txt /tmp/requirements.txt
-COPY infra-requirements.txt /tmp/infra-requirements.txt
 
 RUN conda env update -p ${CONDA_DIR} -f /tmp/environment.yml
 
-
+COPY infra-requirements.txt /tmp/infra-requirements.txt
 RUN pip install --no-cache -r /tmp/infra-requirements.txt
 
 # Install jupyterlab extensions immediately after infra-requirements
@@ -147,15 +145,15 @@ RUN jlpm cache dir && mkdir -p /tmp/yarncache && \
     jlpm config set cache-folder /tmp/yarncache && \
     jupyter labextension install --debug \
             @jupyter-widgets/jupyterlab-manager \
-            jupyter-matplotlib \
+            jupyter-matplotlib@0.7.4 \
             @jupyterlab/geojson-extension \
-            jupyterlab-videochat@0.4 \
+            jupyterlab-videochat \
             ipycanvas  && \
     rm -rf /tmp/yarncache
 
-RUN pip install --no-cache numpy==1.18.5 cython==0.29.21
+RUN pip install --no-cache numpy==1.19.5 cython==0.29.21
 
-
+COPY requirements.txt /tmp/requirements.txt
 RUN pip install --no-cache -r /tmp/requirements.txt
 
 # Set up nbpdf dependencies

--- a/deployments/datahub/images/default/Rprofile.site
+++ b/deployments/datahub/images/default/Rprofile.site
@@ -1,0 +1,6 @@
+local({
+    r <- getOption("repos")
+    r["CRAN"] <- "https://packagemanager.rstudio.com/all/__linux__/focal/latest"
+    options(repos = r)
+    options(HTTPUserAgent = sprintf("R/%s R (%s)", getRversion(), paste(getRversion(), R.version$platform, R.version$arch, R.version$os)))
+})

--- a/deployments/datahub/images/default/environment.yml
+++ b/deployments/datahub/images/default/environment.yml
@@ -1,4 +1,4 @@
 dependencies:
-- nodejs==14.8.*
+- nodejs==12.*
 - pip==20.2.*
 - python==3.8.*

--- a/deployments/datahub/images/default/environment.yml
+++ b/deployments/datahub/images/default/environment.yml
@@ -1,4 +1,4 @@
 dependencies:
-- nodejs==12.*
+- nodejs==15.*
 - pip==20.2.*
 - python==3.8.*

--- a/deployments/datahub/images/default/infra-requirements.txt
+++ b/deployments/datahub/images/default/infra-requirements.txt
@@ -8,18 +8,13 @@
 # everwhere one by one.
 
 # FIXME: Freeze this to get exact versions of all dependencies
-# FIXME: Automate finding out when there are new versions of these
-# Temporary until https://github.com/jupyter/notebook/pull/5870 is released
-git+https://github.com/jupyter/notebook@5a73a8e4026ccc8d7437f788bf0bc2758a73567d
-nbconvert==5.6.1
-nbformat==5.0.7
+notebook==6.1.6
 jupyterlab==2.2.9
 nbgitpuller==0.9.0
-# Temporary fix until https://github.com/yuvipanda/nbresuse/pull/68/commits/87c306f7a604e866e83c6b1f6d4cc8b4015143c6 is merged
-git+https://github.com/yuvipanda/nbresuse.git@87c306f7a604e866e83c6b1f6d4cc8b4015143c6
-jupyterhub==1.1.0
+jupyter-resource-usage==0.5.1
+jupyterhub==1.3.0
 appmode==0.8.0
-ipywidgets==7.5.1
+ipywidgets==7.6.3
 notebook-as-pdf==0.3.1
 otter-grader==1.1.3
 jupyter-tree-download==1.0.1

--- a/deployments/datahub/images/default/infra-requirements.txt
+++ b/deployments/datahub/images/default/infra-requirements.txt
@@ -13,7 +13,7 @@
 git+https://github.com/jupyter/notebook@5a73a8e4026ccc8d7437f788bf0bc2758a73567d
 nbconvert==5.6.1
 nbformat==5.0.7
-jupyterlab==2.2.4
+jupyterlab==2.2.9
 nbgitpuller==0.9.0
 # Temporary fix until https://github.com/yuvipanda/nbresuse/pull/68/commits/87c306f7a604e866e83c6b1f6d4cc8b4015143c6 is merged
 git+https://github.com/yuvipanda/nbresuse.git@87c306f7a604e866e83c6b1f6d4cc8b4015143c6

--- a/deployments/datahub/images/default/install.R
+++ b/deployments/datahub/images/default/install.R
@@ -1,85 +1,114 @@
+#!/usr/bin/env r
+
+
+# Install devtools so we can install versioned packages
+install.packages("devtools")
+
+class_libs_install_version <- function(class_name, class_libs) {
+    print(paste("Installing packages for", class_name))
+    for (i in seq(1, length(class_libs), 2)) {
+        print(paste("Installing", class_libs[i], class_libs[i+1]))
+        devtools::install_version(
+            class_libs[i], version = class_libs[i+1],
+            quiet=TRUE
+        )
+    }
+    print(paste("Done installing packages for", class_name))
+}
+
+
 # R packages to be installed that aren't from apt
+cran_packages = c(
+  "BH", "1.72.0-3",
+  "AER", "1.2-9",
+  "assertthat", "0.2.1",
+  "base64enc", "0.1-3",
+  "bindrcpp", "0.2.2",
+  "broom", "0.7.3",
+  "checkr", "0.5.0",
+  "clipr", "0.7.1",
+  "crosstalk", "1.1.0.1",
+  "crayon", "1.3.4",
+  "curl", "4.3",
+  "data.table", "1.13.6",
+  "DBI", "1.1.0",
+  "digest", "0.6.27",
+  "dplyr", "1.0.2",
+  "e1071", "1.7-4",
+  "evaluate", "0.14",
+  "forcats", "0.5.0",
+  "ggplot2", "3.3.3",
+  "glue", "1.4.2",
+  "haven", "2.3.1",
+  "here", "1.0.1",
+  "highr", "0.8",
+  "hms", "0.5.3",
+  "htmlwidgets", "1.5.3",
+  "httpuv", "1.5.4",
+  "httr", "1.4.2",
+  "ivpack", "1.2",
+  "jsonlite", "1.7.2",
+  "knitr", "1.30",
+  "leaflet", "2.0.3",
+  "lubridate", "1.7.9.2",
+  "mapproj", "1.2.7",
+  "maptools", "1.0-2",
+  "markdown", "1.1",
+  "Matrix", "1.3-0",
+  "matrixStats", "0.57.0",
+  "memoise", "1.1.0",
+  "modelr", "0.1.8",
+  "nlme", "3.1-151",
+  "openssl", "1.4.3",
+  "pander", "0.6.3",
+  "pbdZMQ", "0.3-4",
+  "pillar", "1.4.7",
+  "png", "0.1-7",
+  "praise", "1.0.0",
+  "proto", "1.0.0",
+  "pryr", "0.1.4",
+  "IRkernel", "1.1.1",
+  "rapportools", "1.0",
+  "raster", "3.4-5",
+  "RColorBrewer", "1.1-2",
+  "Rcpp", "1.0.5",
+  "RCurl", "1.98-1.2",
+  "readr", "1.4.0",
+  "readxl", "1.3.1",
+  "rematch", "1.0.1",
+  "repr", "1.1.0",
+  "reprex", "0.3.0",
+  "reshape", "0.8.8",
+  "reticulate", "1.18",
+  "rjson", "0.2.20",
+  "rlang", "0.4.10",
+  "rlist", "0.4.6.1",
+  "rmarkdown", "2.6",
+  "rpart", "4.1-15",
+  "rprojroot", "2.0.2",
+  "selectr", "0.4-2",
+  "shiny", "1.5.0",
+  "sp", "1.4-4",
+  "spatstat", "1.64-1",
+  "spatstat.data", "1.7-0",
+  "spdep", "1.1-5",
+  "stargazer", "5.2.2",
+  "stringi", "1.5.3",
+  "stringr", "1.4.0",
+  "summarytools", "0.9.8",
+  "testthat", "3.0.1",
+  "tibble", "3.0.4",
+  "tidyr", "1.1.2",
+  "tidyverse", "1.3.0",
+  "tinytex", "0.28",
+  "utf8", "1.1.4",
+  "uuid", "0.1-4",
+  "viridis", "0.5.1",
+  "withr", "2.3.0",
+  "xfun", "0.19",
+  "xml2", "1.3.2",
+  "yaml", "2.2.1"
+  ## "lfe", "???" # https://github.com/sgaure/lfe/issues/41
+)
 
-#devtools::install_github('cran/knitr', ref = '7cfb9ac', upgrade_dependencies = FALSE)
-devtools::install_version('knitr', '1.21', upgrade_dependencies = FALSE)
-
-#devtools::install_github('cran/leaflet', ref = 'e0019db', upgrade_dependencies = FALSE)
-devtools::install_version('leaflet', '2.0.1', upgrade_dependencies = FALSE)
-
-#devtools::install_github('cran/spatstat.data', ref = '2e6fa70', upgrade_dependencies = FALSE)
-devtools::install_version('spatstat.data', '1.3-1', upgrade_dependencies = FALSE)
-
-# github ref is version 0.2-3
-devtools::install_github('cran/classint', ref = '9bc40fc', upgrade_dependencies = FALSE)
-
-#devtools::install_github('cran/ggmap', ref = '24118b4', upgrade_dependencies = FALSE)
-devtools::install_version('ggmap', '2.6.1', upgrade_dependencies = FALSE)
-
-#devtools::install_github('cran/rgdal', ref = '8ae242d', upgrade_dependencies = FALSE)
-devtools::install_version('rgdal', '1.3-2', upgrade_dependencies = FALSE)
-
-#devtools::install_github('cran/xfun', ref = '10a9629', upgrade_dependencies = FALSE)
-devtools::install_version('xfun', '0.2', upgrade_dependencies = FALSE)
-
-#devtools::install_github('cran/tinytex', ref = 'a350d5c', upgrade_dependencies = FALSE)
-devtools::install_version('tinytex', '0.5', upgrade_dependencies = FALSE)
-
-#devtools::install_github('cran/rmarkdown', ref = '9e5496f', upgrade_dependencies = FALSE)
-devtools::install_version('rmarkdown', '1.9', upgrade_dependencies = FALSE)
-
-#devtools::install_github('cran/selectr', ref = '7c8ee27', upgrade_dependencies = FALSE)
-devtools::install_version('selectr', '0.4-1', upgrade_dependencies = FALSE)
-
-#devtools::install_github('cran/modelr', ref = 'f4e2b61', upgrade_dependencies = FALSE)
-devtools::install_version('modelr', '0.1.2', upgrade_dependencies = FALSE)
-
-#devtools::install_github('cran/reprex', ref = '25a43c4', upgrade_dependencies = FALSE)
-devtools::install_version('reprex', '0.1.1', upgrade_dependencies = FALSE)
-
-# github ref is version 0.3.2
-devtools::install_github('hadley/revest', ref = '15f265b', upgrade_dependencies = FALSE)
-
-# github ref is version 1.66.0-1
-devtools::install_github('cran/bh', ref = 'bb41077', upgrade_dependencies = FALSE)
-#devtools::install_version('BH', '1.72.0-3')
-
-#devtools::install_github('cran/clipr', ref = 'b95bcb1', upgrade_dependencies = FALSE)
-devtools::install_version('clipr', '0.4.1', upgrade_dependencies = FALSE)
-
-#devtools::install_github('cran/tidyverse', ref = 'bd9ff0b', upgrade_dependencies = FALSE)
-devtools::install_version('tidyverse', '1.2.1', upgrade_dependencies = FALSE)
-
-#devtools::install_github('cran/pander', ref = '06d1de8', upgrade_dependencies = FALSE)
-devtools::install_version('pander', '0.6.3')
-
-#devtools::install_github('cran/pryr', ref = '69edc8d', upgrade_dependencies = FALSE)
-devtools::install_version('pryr', '0.1.3', upgrade_dependencies = FALSE)
-
-#devtools::install_github('cran/rapportools', ref = '6da2f4a', upgrade_dependencies = FALSE)
-devtools::install_version('rapportools', '1.0')
-
-#devtools::install_github('cran/summarytools', ref = '8eeb20a', upgrade_dependencies = FALSE)
-devtools::install_version('summarytools', '0.8.8', upgrade_dependencies = FALSE)
-
-#devtools::install_github('cran/stargazer', ref = '736d303', upgrade_dependencies = FALSE)
-devtools::install_version('stargazer', '5.2.2')
-
-#devtools::install_github('cran/ivpack', ref = 'cc70b77', upgrade_dependencies = FALSE)
-devtools::install_version('ivpack', '1.2')
-
-# github ref is version 0.8.1
-devtools::install_github('cran/dplyr', ref = 'e6ed42a', upgrade_dependencies = FALSE)
-# needs newer bh, but produces compiler error with newer bh
-#devtools::install_version('dplyr', '0.8.1', upgrade_dependencies = FALSE)
-
-# github ref is version 0.8.15
-devtools::install_github('cran/irkernel', ref = '238b691', upgrade_dependencies = FALSE)
-
-devtools::install_version('here', '0.1')
-
-devtools::install_version('checkr', '0.5.0')
-
-devtools::install_version('reticulate', '1.13', upgrade_dependencies=FALSE)
-
-# for EEP118, 2019-11 issue 1154
-devtools::install_version('lfe', '2.8-2', upgrade_dependencies=FALSE)
+class_libs_install_version("Base packages", cran_packages)

--- a/deployments/datahub/images/default/rsession.conf
+++ b/deployments/datahub/images/default/rsession.conf
@@ -1,0 +1,2 @@
+# Use binary packages!
+r-cran-repos=https://packagemanager.rstudio.com/all/__linux__/focal/latest

--- a/deployments/eecs/image/infra-requirements.txt
+++ b/deployments/eecs/image/infra-requirements.txt
@@ -8,18 +8,13 @@
 # everwhere one by one.
 
 # FIXME: Freeze this to get exact versions of all dependencies
-# FIXME: Automate finding out when there are new versions of these
-# Temporary until https://github.com/jupyter/notebook/pull/5870 is released
-git+https://github.com/jupyter/notebook@5a73a8e4026ccc8d7437f788bf0bc2758a73567d
-nbconvert==5.6.1
-nbformat==5.0.7
-jupyterlab==2.2.4
+notebook==6.1.6
+jupyterlab==2.2.9
 nbgitpuller==0.9.0
-# Temporary fix until https://github.com/yuvipanda/nbresuse/pull/68/commits/87c306f7a604e866e83c6b1f6d4cc8b4015143c6 is merged
-git+https://github.com/yuvipanda/nbresuse.git@87c306f7a604e866e83c6b1f6d4cc8b4015143c6
-jupyterhub==1.1.0
+jupyter-resource-usage==0.5.1
+jupyterhub==1.3.0
 appmode==0.8.0
-ipywidgets==7.5.1
+ipywidgets==7.6.3
 notebook-as-pdf==0.3.1
 otter-grader==1.1.3
 jupyter-tree-download==1.0.1

--- a/deployments/highschool/image/infra-requirements.txt
+++ b/deployments/highschool/image/infra-requirements.txt
@@ -8,18 +8,13 @@
 # everwhere one by one.
 
 # FIXME: Freeze this to get exact versions of all dependencies
-# FIXME: Automate finding out when there are new versions of these
-# Temporary until https://github.com/jupyter/notebook/pull/5870 is released
-git+https://github.com/jupyter/notebook@5a73a8e4026ccc8d7437f788bf0bc2758a73567d
-nbconvert==5.6.1
-nbformat==5.0.7
-jupyterlab==2.2.4
+notebook==6.1.6
+jupyterlab==2.2.9
 nbgitpuller==0.9.0
-# Temporary fix until https://github.com/yuvipanda/nbresuse/pull/68/commits/87c306f7a604e866e83c6b1f6d4cc8b4015143c6 is merged
-git+https://github.com/yuvipanda/nbresuse.git@87c306f7a604e866e83c6b1f6d4cc8b4015143c6
-jupyterhub==1.1.0
+jupyter-resource-usage==0.5.1
+jupyterhub==1.3.0
 appmode==0.8.0
-ipywidgets==7.5.1
+ipywidgets==7.6.3
 notebook-as-pdf==0.3.1
 otter-grader==1.1.3
 jupyter-tree-download==1.0.1

--- a/deployments/julia/image/infra-requirements.txt
+++ b/deployments/julia/image/infra-requirements.txt
@@ -8,18 +8,13 @@
 # everwhere one by one.
 
 # FIXME: Freeze this to get exact versions of all dependencies
-# FIXME: Automate finding out when there are new versions of these
-# Temporary until https://github.com/jupyter/notebook/pull/5870 is released
-git+https://github.com/jupyter/notebook@5a73a8e4026ccc8d7437f788bf0bc2758a73567d
-nbconvert==5.6.1
-nbformat==5.0.7
-jupyterlab==2.2.4
+notebook==6.1.6
+jupyterlab==2.2.9
 nbgitpuller==0.9.0
-# Temporary fix until https://github.com/yuvipanda/nbresuse/pull/68/commits/87c306f7a604e866e83c6b1f6d4cc8b4015143c6 is merged
-git+https://github.com/yuvipanda/nbresuse.git@87c306f7a604e866e83c6b1f6d4cc8b4015143c6
-jupyterhub==1.1.0
+jupyter-resource-usage==0.5.1
+jupyterhub==1.3.0
 appmode==0.8.0
-ipywidgets==7.5.1
+ipywidgets==7.6.3
 notebook-as-pdf==0.3.1
 otter-grader==1.1.3
 jupyter-tree-download==1.0.1

--- a/deployments/prob140/image/infra-requirements.txt
+++ b/deployments/prob140/image/infra-requirements.txt
@@ -8,18 +8,13 @@
 # everwhere one by one.
 
 # FIXME: Freeze this to get exact versions of all dependencies
-# FIXME: Automate finding out when there are new versions of these
-# Temporary until https://github.com/jupyter/notebook/pull/5870 is released
-git+https://github.com/jupyter/notebook@5a73a8e4026ccc8d7437f788bf0bc2758a73567d
-nbconvert==5.6.1
-nbformat==5.0.7
-jupyterlab==2.2.4
+notebook==6.1.6
+jupyterlab==2.2.9
 nbgitpuller==0.9.0
-# Temporary fix until https://github.com/yuvipanda/nbresuse/pull/68/commits/87c306f7a604e866e83c6b1f6d4cc8b4015143c6 is merged
-git+https://github.com/yuvipanda/nbresuse.git@87c306f7a604e866e83c6b1f6d4cc8b4015143c6
-jupyterhub==1.1.0
+jupyter-resource-usage==0.5.1
+jupyterhub==1.3.0
 appmode==0.8.0
-ipywidgets==7.5.1
+ipywidgets==7.6.3
 notebook-as-pdf==0.3.1
 otter-grader==1.1.3
 jupyter-tree-download==1.0.1

--- a/deployments/r/image/infra-requirements.txt
+++ b/deployments/r/image/infra-requirements.txt
@@ -8,18 +8,13 @@
 # everwhere one by one.
 
 # FIXME: Freeze this to get exact versions of all dependencies
-# FIXME: Automate finding out when there are new versions of these
-# Temporary until https://github.com/jupyter/notebook/pull/5870 is released
-git+https://github.com/jupyter/notebook@5a73a8e4026ccc8d7437f788bf0bc2758a73567d
-nbconvert==5.6.1
-nbformat==5.0.7
-jupyterlab==2.2.4
+notebook==6.1.6
+jupyterlab==2.2.9
 nbgitpuller==0.9.0
-# Temporary fix until https://github.com/yuvipanda/nbresuse/pull/68/commits/87c306f7a604e866e83c6b1f6d4cc8b4015143c6 is merged
-git+https://github.com/yuvipanda/nbresuse.git@87c306f7a604e866e83c6b1f6d4cc8b4015143c6
-jupyterhub==1.1.0
+jupyter-resource-usage==0.5.1
+jupyterhub==1.3.0
 appmode==0.8.0
-ipywidgets==7.5.1
+ipywidgets==7.6.3
 notebook-as-pdf==0.3.1
 otter-grader==1.1.3
 jupyter-tree-download==1.0.1

--- a/deployments/stat89a/image/infra-requirements.txt
+++ b/deployments/stat89a/image/infra-requirements.txt
@@ -8,18 +8,13 @@
 # everwhere one by one.
 
 # FIXME: Freeze this to get exact versions of all dependencies
-# FIXME: Automate finding out when there are new versions of these
-# Temporary until https://github.com/jupyter/notebook/pull/5870 is released
-git+https://github.com/jupyter/notebook@5a73a8e4026ccc8d7437f788bf0bc2758a73567d
-nbconvert==5.6.1
-nbformat==5.0.7
-jupyterlab==2.2.4
+notebook==6.1.6
+jupyterlab==2.2.9
 nbgitpuller==0.9.0
-# Temporary fix until https://github.com/yuvipanda/nbresuse/pull/68/commits/87c306f7a604e866e83c6b1f6d4cc8b4015143c6 is merged
-git+https://github.com/yuvipanda/nbresuse.git@87c306f7a604e866e83c6b1f6d4cc8b4015143c6
-jupyterhub==1.1.0
+jupyter-resource-usage==0.5.1
+jupyterhub==1.3.0
 appmode==0.8.0
-ipywidgets==7.5.1
+ipywidgets==7.6.3
 notebook-as-pdf==0.3.1
 otter-grader==1.1.3
 jupyter-tree-download==1.0.1

--- a/deployments/template/{{cookiecutter.hub_name}}/image/infra-requirements.txt
+++ b/deployments/template/{{cookiecutter.hub_name}}/image/infra-requirements.txt
@@ -8,18 +8,13 @@
 # everwhere one by one.
 
 # FIXME: Freeze this to get exact versions of all dependencies
-# FIXME: Automate finding out when there are new versions of these
-# Temporary until https://github.com/jupyter/notebook/pull/5870 is released
-git+https://github.com/jupyter/notebook@5a73a8e4026ccc8d7437f788bf0bc2758a73567d
-nbconvert==5.6.1
-nbformat==5.0.7
-jupyterlab==2.2.4
+notebook==6.1.6
+jupyterlab==2.2.9
 nbgitpuller==0.9.0
-# Temporary fix until https://github.com/yuvipanda/nbresuse/pull/68/commits/87c306f7a604e866e83c6b1f6d4cc8b4015143c6 is merged
-git+https://github.com/yuvipanda/nbresuse.git@87c306f7a604e866e83c6b1f6d4cc8b4015143c6
-jupyterhub==1.1.0
+jupyter-resource-usage==0.5.1
+jupyterhub==1.3.0
 appmode==0.8.0
-ipywidgets==7.5.1
+ipywidgets==7.6.3
 notebook-as-pdf==0.3.1
 otter-grader==1.1.3
 jupyter-tree-download==1.0.1

--- a/scripts/infra-packages/requirements.txt
+++ b/scripts/infra-packages/requirements.txt
@@ -8,18 +8,13 @@
 # everwhere one by one.
 
 # FIXME: Freeze this to get exact versions of all dependencies
-# FIXME: Automate finding out when there are new versions of these
-# Temporary until https://github.com/jupyter/notebook/pull/5870 is released
-git+https://github.com/jupyter/notebook@5a73a8e4026ccc8d7437f788bf0bc2758a73567d
-nbconvert==5.6.1
-nbformat==5.0.7
-jupyterlab==2.2.4
+notebook==6.1.6
+jupyterlab==2.2.9
 nbgitpuller==0.9.0
-# Temporary fix until https://github.com/yuvipanda/nbresuse/pull/68/commits/87c306f7a604e866e83c6b1f6d4cc8b4015143c6 is merged
-git+https://github.com/yuvipanda/nbresuse.git@87c306f7a604e866e83c6b1f6d4cc8b4015143c6
-jupyterhub==1.1.0
+jupyter-resource-usage==0.5.1
+jupyterhub==1.3.0
 appmode==0.8.0
-ipywidgets==7.5.1
+ipywidgets==7.6.3
 notebook-as-pdf==0.3.1
 otter-grader==1.1.3
 jupyter-tree-download==1.0.1


### PR DESCRIPTION
- New versions of all apt packages!
- R can now install binary packages from packagemanager.rstudio.com
  This speeds up everything. We also get rid of R package installs
  from apt.
- Newer version of R & RStudio
- Latest versions of all R packages mentioned here are picked
  from packagemanager.rstudio.com
- No python or python libraries version bump.
- data100 also bumped.

Ref #2002