### PR TITLE
Provide separate .rstudio for datahub & r hub

### DIFF
--- a/deployments/datahub/config/common.yaml
+++ b/deployments/datahub/config/common.yaml
@@ -249,6 +249,12 @@ jupyterhub:
           mountPath: /etc/github/github-app-private-key.pem
           subPath: github-app-private-key.pem
           readOnly: true
+        # RStudio can't write session files to anywhere except ~/.rstudio -
+        # only way to change that is by setting $HOME. So instead, we just
+        # bind mount a fresh directory on top of ~/.rstudio!
+        - name: home
+          mountPath: /home/jovyan/.rstudio
+          subPath: '{username}/.datahub-rstudio'
     memory:
       guarantee: 512M
       limit: 1G

--- a/deployments/r/config/common.yaml
+++ b/deployments/r/config/common.yaml
@@ -85,6 +85,12 @@ jupyterhub:
           mountPath: /etc/github/github-app-private-key.pem
           subPath: github-app-private-key.pem
           readOnly: true
+        # RStudio can't write session files to anywhere except ~/.rstudio -
+        # only way to change that is by setting $HOME. So instead, we just
+        # bind mount a fresh directory on top of ~/.rstudio!
+        - name: home
+          mountPath: /home/rstudio/.rstudio
+          subPath: '{username}/.r-hub-rstudio'
     defaultUrl: "/rstudio"
     memory:
       guarantee: 512M


### PR DESCRIPTION
RStudio can't write session files to anywhere except ~/.rstudio -
only way to change that is by setting $HOME. So instead, we just
bind mount a fresh directory on top of ~/.rstudio!

https://github.com/berkeley-dsep-infra/datahub/issues/1899 is
most likely due to two different RStudio versions with
different versions of R writing to the same directory with a
binary serializations from datahub & R hub. We already made the
version the same - but by giving each their own .rstudio, it will
hopefully reduce the likelihood of this.

Ref #1899. Supersedes #1922