### PR TITLE
Install all R hub r packages into datahub image

### DIFF
--- a/deployments/datahub/images/default/Dockerfile
+++ b/deployments/datahub/images/default/Dockerfile
@@ -86,6 +86,9 @@ RUN apt-get update -qq --yes > /dev/null && \
     r-recommended \
     r-cran-littler  > /dev/null
 
+RUN apt update --yes > /dev/null && \
+    apt install --no-install-recommends --yes libpoppler-cpp-dev libx11-dev libglpk-dev libgmp3-dev libxml2-dev > /dev/null
+
 # Needed by RStudio
 RUN apt-get update -qq --yes && \
     apt-get install --yes --no-install-recommends -qq \
@@ -115,16 +118,48 @@ COPY rsession.conf /etc/rstudio/rsession.conf
 RUN sed -i -e '/^R_LIBS_USER=/s/^/#/' /etc/R/Renviron && \
     echo "R_LIBS_USER=${R_LIBS_USER}" >> /etc/R/Renviron
 
+COPY  class-libs.R /tmp/class-libs.R
 # Install all our base R packages
 COPY install.R  /tmp/install.R
 RUN /tmp/install.R && \
     rm -rf /tmp/downloaded_packages
 
+
+RUN mkdir -p /tmp/r-packages
+
+# pdftools
+COPY r-packages/dlab-ctawg.r /tmp/r-packages/
+RUN r /tmp/r-packages/dlab-ctawg.r
+
+COPY r-packages/2019-fall-stat-131a.r /tmp/r-packages
+RUN r /tmp/r-packages/2019-fall-stat-131a.r
+
+COPY r-packages/eep-1118.r /tmp/r-packages
+RUN r /tmp/r-packages/eep-1118.r
+
+COPY r-packages/ias-c188.r /tmp/r-packages
+RUN r /tmp/r-packages/ias-c188.r
+
+COPY r-packages/ph-142.r /tmp/r-packages
+RUN r /tmp/r-packages/ph-142.r
+
+COPY r-packages/stat-131a.r /tmp/r-packages
+RUN r /tmp/r-packages/stat-131a.r
+
+COPY r-packages/2020-spring-envecon-c118.r /tmp/r-packages/
+RUN r /tmp/r-packages/2020-spring-envecon-c118.r
+
+COPY r-packages/econ-140.r /tmp/r-packages/
+RUN r /tmp/r-packages/econ-140.r
+
+COPY r-packages/ph-290.r /tmp/r-packages/
+RUN r /tmp/r-packages/ph-290.r
+
+
 ENV PATH ${CONDA_DIR}/bin:$PATH:/usr/lib/rstudio-server/bin
 
 # Set this to be on container storage, rather than under $HOME
 ENV IPYTHONDIR ${CONDA_DIR}/etc/ipython
-
 
 WORKDIR /home/${NB_USER}
 

--- a/deployments/datahub/images/default/class-libs.R
+++ b/deployments/datahub/images/default/class-libs.R
@@ -1,0 +1,20 @@
+#!/usr/bin/env Rscript
+
+class_libs_install_version <- function(class_name, class_libs) {
+  print(paste("Installing packages for", class_name))
+  for (i in seq(1, length(class_libs), 2)) {
+    installed_packages <- rownames(installed.packages())
+    package_name = class_libs[i]
+    version = class_libs[i+1]
+    # Only install packages if they haven't already been installed!
+    # devtools doesn't do that by default
+    if (!package_name %in% installed_packages) {
+      print(paste("Installing", package_name, version))
+      devtools::install_version(package_name, version, quiet=TRUE)
+    } else {
+      # FIXME: This ignores version incompatibilities :'(
+      print(paste("Not installing", package_name, " as it is already installed"))
+    }
+  }
+  print(paste("Done installing packages for", class_name))
+}

--- a/deployments/datahub/images/default/install.R
+++ b/deployments/datahub/images/default/install.R
@@ -4,111 +4,198 @@
 # Install devtools so we can install versioned packages
 install.packages("devtools")
 
-class_libs_install_version <- function(class_name, class_libs) {
-    print(paste("Installing packages for", class_name))
-    for (i in seq(1, length(class_libs), 2)) {
-        print(paste("Installing", class_libs[i], class_libs[i+1]))
-        devtools::install_version(
-            class_libs[i], version = class_libs[i+1],
-            quiet=TRUE
-        )
-    }
-    print(paste("Done installing packages for", class_name))
-}
+source("/tmp/class-libs.R")
 
+# dplyr package + backends
+# From https://github.com/rocker-org/rocker-versioned2/blob/b8d23396468c5dc73115cce6c5716424d80ffcb0/scripts/install_tidyverse.sh#L30
+dplyr_packages = c(
+  "dplyr", "1.0.2",
+  "arrow", "2.0.0",
+  "dbplyr", "2.0.0",
+  "DBI", "1.1.0",
+  "dtplyr", "1.0.1",
+  "nycflights13", "1.0.1",
+  "Lahman", "8.0-0",
+  "RMariaDB", "1.1.0",
+  "RPostgres", "1.3.0",
+  "RSQLite", "2.2.1",
+  "fst", "0.9.4"
+)
 
+# From https://github.com/rocker-org/rocker-versioned2/blob/b8d23396468c5dc73115cce6c5716424d80ffcb0/scripts/install_verse.sh#L82
+publishing_packages = c(
+  "tinytex", "0.28",
+  "blogdown", "0.21",
+  "bookdown", "0.21",
+  "rticles", "0.18",
+  "rmdshower", "2.1.1",
+  "rJava", "0.9-13",
+  "xaringan", "0.19"
+)
 # R packages to be installed that aren't from apt
+# Combination of informal requests & rocker image suggestions
+# Some of these were already in datahub image
 cran_packages = c(
-  "BH", "1.72.0-3",
+
   "AER", "1.2-9",
+  "BH", "1.72.0-3",
+  "BiocManager", "1.30.10",
+  "DBI", "1.1.0",
+  "FNN", "1.1.3",
+  "IRkernel", "1.1.1",
+  "Matrix", "1.3-0",
+  "R.methodsS3", "1.8.1",
+  "R.oo", "1.24.0",
+  "R.utils", "2.10.1",
+  "RCSF", "1.0.2",
+  "RColorBrewer", "1.1-2",
+  "RCurl", "1.98-1.2",
+  "RNetCDF", "2.4-2",
+  "RandomFields", "3.3.8",
+  "RandomFieldsUtils", "0.5.3",
+  "Rcpp", "1.0.5",
+  "RcppProgress", "0.4.2",
   "assertthat", "0.2.1",
   "base64enc", "0.1-3",
+  "bibtex", "0.4.2.3",
   "bindrcpp", "0.2.2",
   "broom", "0.7.3",
   "checkr", "0.5.0",
   "clipr", "0.7.1",
-  "crosstalk", "1.1.0.1",
   "crayon", "1.3.4",
+  "crosstalk", "1.1.0.1",
   "curl", "4.3",
   "data.table", "1.13.6",
-  "DBI", "1.1.0",
+  "dichromat", "2.0-0",
   "digest", "0.6.27",
-  "dplyr", "1.0.2",
+  "docopt", "0.7.1",
   "e1071", "1.7-4",
   "evaluate", "0.14",
   "forcats", "0.5.0",
+  "future", "1.21.0",
+  "gdalUtils", "2.0.3.2",
+  "gdtools", "0.2.3",
+  "geoR", "1.8-1",
+  "geometry", "0.4.5",
+  "geosphere", "1.5-10",
+  "gert", "1.0.2",
   "ggplot2", "3.3.3",
+  "git2r", "0.27.1",
+  "globals", "0.14.0",
   "glue", "1.4.2",
+  "gstat", "2.0-6",
   "haven", "2.3.1",
+  "hdf5r", "1.3.3",
   "here", "1.0.1",
   "highr", "0.8",
   "hms", "0.5.3",
   "htmlwidgets", "1.5.3",
   "httpuv", "1.5.4",
   "httr", "1.4.2",
+  "intervals", "0.15.2",
   "ivpack", "1.2",
   "jsonlite", "1.7.2",
   "knitr", "1.30",
+  "leafem", "0.1.3",
   "leaflet", "2.0.3",
+  "leafpop", "0.0.6",
+  "leafsync", "0.1.0",
+  "learnr", "0.10.1",
+  "linprog", "0.9-2",
+  "listenv", "0.8.0",
+  "lpSolve", "5.6.15",
   "lubridate", "1.7.9.2",
+  "lwgeom", "0.2-5",
+  "magic", "1.5-9",
+  "manipulateWidget", "0.10.1",
+  "mapdata", "2.3.0",
   "mapproj", "1.2.7",
   "maptools", "1.0-2",
+  "mapview", "2.9.0",
   "markdown", "1.1",
-  "Matrix", "1.3-0",
   "matrixStats", "0.57.0",
   "memoise", "1.1.0",
+  "miniUI", "0.1.1.1",
   "modelr", "0.1.8",
+  "ncdf4", "1.17",
+  "ncmeta", "0.3.0",
   "nlme", "3.1-151",
   "openssl", "1.4.3",
+  "packrat", "0.5.0",
   "pander", "0.6.3",
   "pbdZMQ", "0.3-4",
   "pillar", "1.4.7",
   "png", "0.1-7",
   "praise", "1.0.0",
+  "proj4", "1.0-10",
   "proto", "1.0.0",
   "pryr", "0.1.4",
-  "IRkernel", "1.1.1",
   "rapportools", "1.0",
   "raster", "3.4-5",
-  "RColorBrewer", "1.1-2",
-  "Rcpp", "1.0.5",
-  "RCurl", "1.98-1.2",
   "readr", "1.4.0",
   "readxl", "1.3.1",
+  "redland", "1.0.17-14",
   "rematch", "1.0.1",
   "repr", "1.1.0",
   "reprex", "0.3.0",
   "reshape", "0.8.8",
   "reticulate", "1.18",
+  "rgeos", "0.5-5",
+  "rgl", "0.103.5",
   "rjson", "0.2.20",
   "rlang", "0.4.10",
+  "rlas", "1.3.8",
   "rlist", "0.4.6.1",
   "rmarkdown", "2.6",
   "rpart", "4.1-15",
   "rprojroot", "2.0.2",
+  "rsconnect", "0.8.16",
+  "satellite", "1.0.2",
   "selectr", "0.4-2",
   "shiny", "1.5.0",
   "sp", "1.4-4",
+  "spacetime", "1.2-3",
+  "spatialreg", "1.1-5",
   "spatstat", "1.64-1",
   "spatstat.data", "1.7-0",
   "spdep", "1.1-5",
+  "splancs", "2.01-40",
   "stargazer", "5.2.2",
+  "stars", "0.4-3",
   "stringi", "1.5.3",
   "stringr", "1.4.0",
   "summarytools", "0.9.8",
+  "svglite", "1.2.3.2",
+  "systemfonts", "0.3.2",
+  "testit", "0.12",
   "testthat", "3.0.1",
   "tibble", "3.0.4",
+  "tidync", "0.2.4",
   "tidyr", "1.1.2",
   "tidyverse", "1.3.0",
-  "tinytex", "0.28",
+  "tmap", "3.2",
+  "tmaptools", "3.1",
+  "tufte", "0.9",
   "utf8", "1.1.4",
   "uuid", "0.1-4",
   "viridis", "0.5.1",
+  "vroom", "1.3.2",
+  "whoami", "1.3.0",
+  "widgetframe", "0.3.1",
   "withr", "2.3.0",
   "xfun", "0.19",
   "xml2", "1.3.2",
+  "xts", "0.12.1",
   "yaml", "2.2.1"
   ## "lfe", "???" # https://github.com/sgaure/lfe/issues/41
-)
+  )
 
 class_libs_install_version("Base packages", cran_packages)
+class_libs_install_version("dplyr packages", dplyr_packages)
+class_libs_install_version("publishing packages", publishing_packages)
+
+# Bioconductor packages present in rocker images
+# FIXME: Find a way to version these?
+# FIXME: Make sure these are binary installs?
+BiocManager::install('rhdf5')
+BiocManager::install('Rhdf5lib')

--- a/deployments/datahub/images/default/r-packages/2019-fall-stat-131a.r
+++ b/deployments/datahub/images/default/r-packages/2019-fall-stat-131a.r
@@ -1,0 +1,26 @@
+#!/usr/bin/env Rscript
+
+source("/tmp/class-libs.R")
+
+class_name = "2019 Fall Stat 131a"
+BiocManager::install('Biobase')
+class_libs = c(
+  "alluvial", "0.1-2",
+  "latticeExtra", "0.6-29",
+  "DAAG", "1.24",
+  "faraway", "1.0.7",
+  "fdrtool", "1.2.16",
+  "gpairs", "1.3.3",
+  "gplots", "3.1.1",
+  "hexbin", "1.28.1",
+  "leaps", "3.1",
+  "NMF", "0.23.0",
+  "randomForest", "4.6-14",
+  "rpart.plot", "3.0.9",
+  "scatterplot3d", "0.3-41",
+  "shape", "1.4.5",
+  "sm", "2.2-5.6",
+  "pheatmap", "1.0.12",
+  "vioplot", "0.3.5"
+)
+class_libs_install_version(class_name, class_libs)

--- a/deployments/datahub/images/default/r-packages/2020-spring-envecon-c118.r
+++ b/deployments/datahub/images/default/r-packages/2020-spring-envecon-c118.r
@@ -1,0 +1,9 @@
+#!/usr/bin/env Rscript
+
+source("/tmp/class-libs.R")
+
+class_name = "2020 Spring Env Econ C118"
+class_libs = c(
+  "margins", "0.3.23"
+)
+class_libs_install_version(class_name, class_libs)

--- a/deployments/datahub/images/default/r-packages/dlab-ctawg.r
+++ b/deployments/datahub/images/default/r-packages/dlab-ctawg.r
@@ -1,0 +1,15 @@
+# https://github.com/berkeley-dsep-infra/datahub/issues/1942
+print("Installing packages for DLab CTAWG")
+
+source("/tmp/class-libs.R")
+class_name = "D-Lab CTAWG"
+
+class_libs = c(
+  "qpdf", "1.1",
+  # needs libpoppler-cpp-dev
+  "pdftools", "2.3.1",
+  # needs libx11-dev
+  "imager", "0.42.3"
+)
+
+class_libs_install_version(class_name, class_libs)

--- a/deployments/datahub/images/default/r-packages/econ-140.r
+++ b/deployments/datahub/images/default/r-packages/econ-140.r
@@ -1,0 +1,12 @@
+#!/usr/bin/env Rscript
+
+print("Installing packages for Econ 140")
+
+source("/tmp/class-libs.R")
+
+class_name = "Econ 140"
+
+print("Installing ottr...")
+devtools::install_github('ucbds-infra/ottr', ref='0.0.1.b1', upgrade_dependencies=FALSE, quiet=FALSE)
+
+print("Done installing packages for Econ 140")

--- a/deployments/datahub/images/default/r-packages/eep-1118.r
+++ b/deployments/datahub/images/default/r-packages/eep-1118.r
@@ -1,0 +1,17 @@
+#!/usr/bin/env Rscript
+# From https://github.com/berkeley-dsep-infra/datahub/issues/1103
+# eep 1118, fall 2019/spring 2020
+
+print("Installing packages for EEP 1118")
+
+source("/tmp/class-libs.R")
+
+class_name="EEP 1118"
+class_libs = c(
+    "car", "3.0-10"
+)
+
+class_libs_install_version(class_name, class_libs)
+
+print("Done installing packages for EEP 1118")
+

--- a/deployments/datahub/images/default/r-packages/ias-c188.r
+++ b/deployments/datahub/images/default/r-packages/ias-c188.r
@@ -1,0 +1,16 @@
+#!/usr/bin/env Rscript
+# From https://github.com/berkeley-dsep-infra/datahub/issues/814
+#      https://github.com/berkeley-dsep-infra/datahub/issues/897
+
+source("/tmp/class-libs.R")
+
+class_name = "IA C188"
+class_libs = c(
+  "rdd", "0.57",
+  "lm.beta", "1.5-1",
+  "multcomp", "1.4-15"
+  # "lfe", "???" # https://github.com/sgaure/lfe/issues/41
+)
+
+class_libs_install_version(class_name, class_libs)
+

--- a/deployments/datahub/images/default/r-packages/ph-142.r
+++ b/deployments/datahub/images/default/r-packages/ph-142.r
@@ -1,0 +1,28 @@
+#!/usr/bin/env Rscript
+                                        # From https://github.com/berkeley-dsep-infra/datahub/issues/881
+print("Installing packages for PH142")
+
+source("/tmp/class-libs.R")
+
+class_name = "PH142"
+
+class_libs = c(
+  "fGarch", "3042.83.2",
+  "SASxport", "1.7.0",
+  "googlesheets", "0.3.0",
+  "googledrive", "1.0.1",
+  "ggrepel", "0.9.0",
+  "infer", "0.5.3",
+  "janitor", "2.1.0",
+  "latex2exp", "0.4.0",
+  "measurements", "1.4.0",
+  "dagitty", "0.3-0",
+  "cowplot", "1.1.1",
+  "patchwork", "1.1.1",
+  "tigris", "1.0",
+  "googlesheets4", "0.2.0"
+)
+
+class_libs_install_version(class_name, class_libs)
+
+print("Done installing packages for PH142")

--- a/deployments/datahub/images/default/r-packages/ph-290.r
+++ b/deployments/datahub/images/default/r-packages/ph-290.r
@@ -1,0 +1,16 @@
+#!/usr/bin/env Rscript
+# For https://github.com/berkeley-dsep-infra/datahub/issues/1921
+print("Installing packages for PH 290W")
+
+source("/tmp/class-libs.R")
+
+class_name = "PH 290W"
+
+class_libs = c(
+  "kableExtra", "1.3.1",
+  "plotly", "4.9.2.2",
+  "ggthemes", "4.2.0",
+  "formattable", "0.2.1"
+)
+
+class_libs_install_version(class_name, class_libs)

--- a/deployments/datahub/images/default/r-packages/stat-131a.r
+++ b/deployments/datahub/images/default/r-packages/stat-131a.r
@@ -1,0 +1,7 @@
+#!/usr/bin/env Rscript
+
+source("/tmp/class-libs.R")
+
+class_name = "Stat 131a"
+
+devtools::install_github('DataComputing/DataComputing', ref='d5cebba')

--- a/scripts/list-packages.py
+++ b/scripts/list-packages.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""
+Lists R packages in one docker image but not the other
+"""
+import docker
+import argparse
+import json
+from urllib.request import urlopen
+from urllib.error import HTTPError
+
+argparser = argparse.ArgumentParser()
+argparser.add_argument(
+    'src_image',
+)
+
+argparser.add_argument(
+    'dest_image',
+)
+
+args = argparser.parse_args()
+
+client = docker.from_env()
+
+
+def get_package_info(package_name):
+    """
+    Return package data for package_name in CRAN repo
+    """
+    url = f'https://packagemanager.rstudio.com/__api__/repos/1/packages/{package_name}'
+
+    try:
+        with urlopen(url) as resp:
+            data = json.load(resp)
+    except HTTPError as e:
+        # Provide an informative exception if we have a typo in package name
+        if e.code == 404:
+            # Package doesn't exist
+            print(f'Package "{package_name}" not found in package manager')
+            return { "name": package_name, "version": None }
+        else:
+            raise
+    return data
+
+def packages_list(image_name):
+    raw_packages = client.containers.run(
+        image_name,
+        'R --quiet -e "installed.packages()[,c(1, 3)]"'
+    ).decode().split('\n')[2:]
+
+    return set([rp.split()[0] for rp in raw_packages if len(rp.split()) == 3])
+
+def main():
+    src_packages = packages_list(args.src_image)
+    dest_packages = packages_list(args.dest_image)
+
+    to_be_added =  src_packages - dest_packages
+
+    for p in to_be_added:
+        info = get_package_info(p)
+        print(f'"{p}", "{info["version"]}",')
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
We want to use the exact same image for both the R
and main datahubs. This reduces maintenance burden and possible
issues from mixing code / environment between datahub & R hub.

To try make these equivalent, we:

- Install everything from the rocker/geospatial image we
  used
- Move all the class-specific packages we had installed
- Upgrade all versions of all packages
- Minor improvements to how packages are installed

Hopefully, this has caught all the packages. These are binary
packages, so some might need apt packages to be installed as
well to run. Let's keep an eye out for those.

Ref #2002 