### PR TITLE
Install jupyterlab 3.0

### DIFF
--- a/deployments/biology/image/infra-requirements.txt
+++ b/deployments/biology/image/infra-requirements.txt
@@ -13,13 +13,13 @@
 git+https://github.com/jupyter/notebook@5a73a8e4026ccc8d7437f788bf0bc2758a73567d
 nbconvert==5.6.1
 nbformat==5.0.7
-jupyterlab==2.2.4
+jupyterlab==3.0.4
 nbgitpuller==0.9.0
 # Temporary fix until https://github.com/yuvipanda/nbresuse/pull/68/commits/87c306f7a604e866e83c6b1f6d4cc8b4015143c6 is merged
 git+https://github.com/yuvipanda/nbresuse.git@87c306f7a604e866e83c6b1f6d4cc8b4015143c6
 jupyterhub==1.3.0
 appmode==0.8.0
-ipywidgets==7.5.1
+ipywidgets==7.6.3
 notebook-as-pdf==0.3.1
 otter-grader==1.1.3
 jupyter-tree-download==1.0.1

--- a/deployments/data100/image/Dockerfile
+++ b/deployments/data100/image/Dockerfile
@@ -70,7 +70,3 @@ RUN conda env update -p ${CONDA_DIR} -f /tmp/environment.yml
 # Set bash as shell in terminado.
 # Disable history.
 ADD ipython_config.py ${CONDA_PREFIX}/envs/data100/etc/ipython/
-
-RUN jupyter labextension install @jupyter-widgets/jupyterlab-manager@2.0.0 \
-                                 jupyterlab-plotly@4.8.1  \
-                                 plotlywidget@4.8.1

--- a/deployments/data100/image/infra-requirements.txt
+++ b/deployments/data100/image/infra-requirements.txt
@@ -13,13 +13,13 @@
 git+https://github.com/jupyter/notebook@5a73a8e4026ccc8d7437f788bf0bc2758a73567d
 nbconvert==5.6.1
 nbformat==5.0.7
-jupyterlab==2.2.4
+jupyterlab==3.0.4
 nbgitpuller==0.9.0
 # Temporary fix until https://github.com/yuvipanda/nbresuse/pull/68/commits/87c306f7a604e866e83c6b1f6d4cc8b4015143c6 is merged
 git+https://github.com/yuvipanda/nbresuse.git@87c306f7a604e866e83c6b1f6d4cc8b4015143c6
 jupyterhub==1.3.0
 appmode==0.8.0
-ipywidgets==7.5.1
+ipywidgets==7.6.3
 notebook-as-pdf==0.3.1
 otter-grader==1.1.3
 jupyter-tree-download==1.0.1

--- a/deployments/data102/image/infra-requirements.txt
+++ b/deployments/data102/image/infra-requirements.txt
@@ -13,13 +13,13 @@
 git+https://github.com/jupyter/notebook@5a73a8e4026ccc8d7437f788bf0bc2758a73567d
 nbconvert==5.6.1
 nbformat==5.0.7
-jupyterlab==2.2.4
+jupyterlab==3.0.4
 nbgitpuller==0.9.0
 # Temporary fix until https://github.com/yuvipanda/nbresuse/pull/68/commits/87c306f7a604e866e83c6b1f6d4cc8b4015143c6 is merged
 git+https://github.com/yuvipanda/nbresuse.git@87c306f7a604e866e83c6b1f6d4cc8b4015143c6
 jupyterhub==1.3.0
 appmode==0.8.0
-ipywidgets==7.5.1
+ipywidgets==7.6.3
 notebook-as-pdf==0.3.1
 otter-grader==1.1.3
 jupyter-tree-download==1.0.1

--- a/deployments/data102/image/postBuild
+++ b/deployments/data102/image/postBuild
@@ -1,9 +1,4 @@
 #!/bin/bash
 
 set -euo pipefail
-jupyter labextension install \
-        @jupyter-widgets/jupyterlab-manager@2.0.0 \
-        jupyterlab-plotly@4.8.1  \
-        plotlywidget@4.8.1 \
-        jupyter-matplotlib@0.7.2 \
-        @jupyterlab/geojson-extension@2.0.1
+jupyter labextension install @jupyterlab/geojson-extension

--- a/deployments/data8x/image/infra-requirements.txt
+++ b/deployments/data8x/image/infra-requirements.txt
@@ -13,13 +13,13 @@
 git+https://github.com/jupyter/notebook@5a73a8e4026ccc8d7437f788bf0bc2758a73567d
 nbconvert==5.6.1
 nbformat==5.0.7
-jupyterlab==2.2.4
+jupyterlab==3.0.4
 nbgitpuller==0.9.0
 # Temporary fix until https://github.com/yuvipanda/nbresuse/pull/68/commits/87c306f7a604e866e83c6b1f6d4cc8b4015143c6 is merged
 git+https://github.com/yuvipanda/nbresuse.git@87c306f7a604e866e83c6b1f6d4cc8b4015143c6
 jupyterhub==1.3.0
 appmode==0.8.0
-ipywidgets==7.5.1
+ipywidgets==7.6.3
 notebook-as-pdf==0.3.1
 otter-grader==1.1.3
 jupyter-tree-download==1.0.1

--- a/deployments/datahub/images/default/Dockerfile
+++ b/deployments/datahub/images/default/Dockerfile
@@ -184,11 +184,8 @@ RUN pip install --no-cache -r /tmp/infra-requirements.txt
 RUN jlpm cache dir && mkdir -p /tmp/yarncache && \
     jlpm config set cache-folder /tmp/yarncache && \
     jupyter labextension install --debug \
-            @jupyter-widgets/jupyterlab-manager \
-            jupyter-matplotlib@0.7.4 \
-            @jupyterlab/geojson-extension \
-            jupyterlab-videochat \
-            ipycanvas  && \
+        @jupyterlab/geojson-extension \
+        jupyterlab-plotly@4.14.3 && \
     rm -rf /tmp/yarncache
 
 RUN pip install --no-cache numpy==1.19.5 cython==0.29.21

--- a/deployments/datahub/images/default/infra-requirements.txt
+++ b/deployments/datahub/images/default/infra-requirements.txt
@@ -13,13 +13,13 @@
 git+https://github.com/jupyter/notebook@5a73a8e4026ccc8d7437f788bf0bc2758a73567d
 nbconvert==5.6.1
 nbformat==5.0.7
-jupyterlab==2.2.4
+jupyterlab==3.0.4
 nbgitpuller==0.9.0
 # Temporary fix until https://github.com/yuvipanda/nbresuse/pull/68/commits/87c306f7a604e866e83c6b1f6d4cc8b4015143c6 is merged
 git+https://github.com/yuvipanda/nbresuse.git@87c306f7a604e866e83c6b1f6d4cc8b4015143c6
 jupyterhub==1.3.0
 appmode==0.8.0
-ipywidgets==7.5.1
+ipywidgets==7.6.3
 notebook-as-pdf==0.3.1
 otter-grader==1.1.3
 jupyter-tree-download==1.0.1

--- a/deployments/datahub/images/default/requirements.txt
+++ b/deployments/datahub/images/default/requirements.txt
@@ -2,11 +2,11 @@
 # data8; foundation
 datascience==0.15.6
 matplotlib==3.1.3
+ipympl==0.6.2
 pandas==1.1.0
 scipy==1.5.2
 statsmodels==0.11.1
 okpy==1.18.1
-ipympl==0.5.7
 folium==0.11
 #
 # r
@@ -97,7 +97,7 @@ ffmpeg-python==0.2.0
 Cartopy==0.18.0 --no-binary Cartopy
 
 # data 88; spring 2020
-plotly==4.9.0
+plotly==4.14.3
 mpmath==1.1.0
 sympy==1.6.2
 chart-studio==1.1.0
@@ -154,4 +154,4 @@ graphviz
 habanero==0.7.4
 
 # https://github.com/berkeley-dsep-infra/datahub/issues/1981
-ipycanvas==0.7.0
+ipycanvas==0.8.1

--- a/deployments/eecs/image/infra-requirements.txt
+++ b/deployments/eecs/image/infra-requirements.txt
@@ -13,13 +13,13 @@
 git+https://github.com/jupyter/notebook@5a73a8e4026ccc8d7437f788bf0bc2758a73567d
 nbconvert==5.6.1
 nbformat==5.0.7
-jupyterlab==2.2.4
+jupyterlab==3.0.4
 nbgitpuller==0.9.0
 # Temporary fix until https://github.com/yuvipanda/nbresuse/pull/68/commits/87c306f7a604e866e83c6b1f6d4cc8b4015143c6 is merged
 git+https://github.com/yuvipanda/nbresuse.git@87c306f7a604e866e83c6b1f6d4cc8b4015143c6
 jupyterhub==1.3.0
 appmode==0.8.0
-ipywidgets==7.5.1
+ipywidgets==7.6.3
 notebook-as-pdf==0.3.1
 otter-grader==1.1.3
 jupyter-tree-download==1.0.1

--- a/deployments/eecs/image/postBuild
+++ b/deployments/eecs/image/postBuild
@@ -6,6 +6,4 @@ mkdir -p ${CONDA_DIR}/etc/ipython
 cp ipython_config.py ${CONDA_DIR}/etc/ipython/ipython_config.py
 
 # Install JupyterLab extensions
-jupyter labextension install \
-    @jupyter-widgets/jupyterlab-manager \
-    @jupyterlab/server-proxy
+jupyter labextension install @jupyterlab/server-proxy

--- a/deployments/highschool/image/infra-requirements.txt
+++ b/deployments/highschool/image/infra-requirements.txt
@@ -13,13 +13,13 @@
 git+https://github.com/jupyter/notebook@5a73a8e4026ccc8d7437f788bf0bc2758a73567d
 nbconvert==5.6.1
 nbformat==5.0.7
-jupyterlab==2.2.4
+jupyterlab==3.0.4
 nbgitpuller==0.9.0
 # Temporary fix until https://github.com/yuvipanda/nbresuse/pull/68/commits/87c306f7a604e866e83c6b1f6d4cc8b4015143c6 is merged
 git+https://github.com/yuvipanda/nbresuse.git@87c306f7a604e866e83c6b1f6d4cc8b4015143c6
 jupyterhub==1.3.0
 appmode==0.8.0
-ipywidgets==7.5.1
+ipywidgets==7.6.3
 notebook-as-pdf==0.3.1
 otter-grader==1.1.3
 jupyter-tree-download==1.0.1

--- a/deployments/julia/image/infra-requirements.txt
+++ b/deployments/julia/image/infra-requirements.txt
@@ -13,13 +13,13 @@
 git+https://github.com/jupyter/notebook@5a73a8e4026ccc8d7437f788bf0bc2758a73567d
 nbconvert==5.6.1
 nbformat==5.0.7
-jupyterlab==2.2.4
+jupyterlab==3.0.4
 nbgitpuller==0.9.0
 # Temporary fix until https://github.com/yuvipanda/nbresuse/pull/68/commits/87c306f7a604e866e83c6b1f6d4cc8b4015143c6 is merged
 git+https://github.com/yuvipanda/nbresuse.git@87c306f7a604e866e83c6b1f6d4cc8b4015143c6
 jupyterhub==1.3.0
 appmode==0.8.0
-ipywidgets==7.5.1
+ipywidgets==7.6.3
 notebook-as-pdf==0.3.1
 otter-grader==1.1.3
 jupyter-tree-download==1.0.1

--- a/deployments/prob140/image/infra-requirements.txt
+++ b/deployments/prob140/image/infra-requirements.txt
@@ -13,13 +13,13 @@
 git+https://github.com/jupyter/notebook@5a73a8e4026ccc8d7437f788bf0bc2758a73567d
 nbconvert==5.6.1
 nbformat==5.0.7
-jupyterlab==2.2.4
+jupyterlab==3.0.4
 nbgitpuller==0.9.0
 # Temporary fix until https://github.com/yuvipanda/nbresuse/pull/68/commits/87c306f7a604e866e83c6b1f6d4cc8b4015143c6 is merged
 git+https://github.com/yuvipanda/nbresuse.git@87c306f7a604e866e83c6b1f6d4cc8b4015143c6
 jupyterhub==1.3.0
 appmode==0.8.0
-ipywidgets==7.5.1
+ipywidgets==7.6.3
 notebook-as-pdf==0.3.1
 otter-grader==1.1.3
 jupyter-tree-download==1.0.1

--- a/deployments/r/hubploy.yaml
+++ b/deployments/r/hubploy.yaml
@@ -1,5 +1,7 @@
 images:
-  image_name: gcr.io/ucb-datahub-2018/r-user-image
+  images:
+    - name: gcr.io/ucb-datahub-2018/primary-user-image
+      path: ../datahub/images/default
   registry:
     provider: gcloud
     gcloud:

--- a/deployments/r/image/infra-requirements.txt
+++ b/deployments/r/image/infra-requirements.txt
@@ -13,13 +13,13 @@
 git+https://github.com/jupyter/notebook@5a73a8e4026ccc8d7437f788bf0bc2758a73567d
 nbconvert==5.6.1
 nbformat==5.0.7
-jupyterlab==2.2.4
+jupyterlab==3.0.4
 nbgitpuller==0.9.0
 # Temporary fix until https://github.com/yuvipanda/nbresuse/pull/68/commits/87c306f7a604e866e83c6b1f6d4cc8b4015143c6 is merged
 git+https://github.com/yuvipanda/nbresuse.git@87c306f7a604e866e83c6b1f6d4cc8b4015143c6
 jupyterhub==1.3.0
 appmode==0.8.0
-ipywidgets==7.5.1
+ipywidgets==7.6.3
 notebook-as-pdf==0.3.1
 otter-grader==1.1.3
 jupyter-tree-download==1.0.1

--- a/deployments/stat89a/image/infra-requirements.txt
+++ b/deployments/stat89a/image/infra-requirements.txt
@@ -13,13 +13,13 @@
 git+https://github.com/jupyter/notebook@5a73a8e4026ccc8d7437f788bf0bc2758a73567d
 nbconvert==5.6.1
 nbformat==5.0.7
-jupyterlab==2.2.4
+jupyterlab==3.0.4
 nbgitpuller==0.9.0
 # Temporary fix until https://github.com/yuvipanda/nbresuse/pull/68/commits/87c306f7a604e866e83c6b1f6d4cc8b4015143c6 is merged
 git+https://github.com/yuvipanda/nbresuse.git@87c306f7a604e866e83c6b1f6d4cc8b4015143c6
 jupyterhub==1.3.0
 appmode==0.8.0
-ipywidgets==7.5.1
+ipywidgets==7.6.3
 notebook-as-pdf==0.3.1
 otter-grader==1.1.3
 jupyter-tree-download==1.0.1

--- a/deployments/stat89a/image/postBuild
+++ b/deployments/stat89a/image/postBuild
@@ -14,10 +14,3 @@ cp themes.jupyterlab-settings $HOME/.jupyter/lab/user-settings/@jupyterlab/apput
 # run matplotlib once to generate the font cache
 python -c "import matplotlib as mpl; mpl.use('Agg'); import pylab as plt; fig, ax = plt.subplots(); fig.savefig('test.png')"
 test -e test.png && rm test.png
-
-#    Install necessary JupyterLab extensions
-jupyter labextension install --debug \
-     @jupyter-widgets/jupyterlab-manager \
-     jupyter-matplotlib \
-     jupyterlab-plotly \
-     plotlywidget

--- a/deployments/template/{{cookiecutter.hub_name}}/image/infra-requirements.txt
+++ b/deployments/template/{{cookiecutter.hub_name}}/image/infra-requirements.txt
@@ -13,13 +13,13 @@
 git+https://github.com/jupyter/notebook@5a73a8e4026ccc8d7437f788bf0bc2758a73567d
 nbconvert==5.6.1
 nbformat==5.0.7
-jupyterlab==2.2.4
+jupyterlab==3.0.4
 nbgitpuller==0.9.0
 # Temporary fix until https://github.com/yuvipanda/nbresuse/pull/68/commits/87c306f7a604e866e83c6b1f6d4cc8b4015143c6 is merged
 git+https://github.com/yuvipanda/nbresuse.git@87c306f7a604e866e83c6b1f6d4cc8b4015143c6
 jupyterhub==1.3.0
 appmode==0.8.0
-ipywidgets==7.5.1
+ipywidgets==7.6.3
 notebook-as-pdf==0.3.1
 otter-grader==1.1.3
 jupyter-tree-download==1.0.1

--- a/scripts/infra-packages/requirements.txt
+++ b/scripts/infra-packages/requirements.txt
@@ -13,13 +13,13 @@
 git+https://github.com/jupyter/notebook@5a73a8e4026ccc8d7437f788bf0bc2758a73567d
 nbconvert==5.6.1
 nbformat==5.0.7
-jupyterlab==2.2.4
+jupyterlab==3.0.4
 nbgitpuller==0.9.0
 # Temporary fix until https://github.com/yuvipanda/nbresuse/pull/68/commits/87c306f7a604e866e83c6b1f6d4cc8b4015143c6 is merged
 git+https://github.com/yuvipanda/nbresuse.git@87c306f7a604e866e83c6b1f6d4cc8b4015143c6
 jupyterhub==1.3.0
 appmode==0.8.0
-ipywidgets==7.5.1
+ipywidgets==7.6.3
 notebook-as-pdf==0.3.1
 otter-grader==1.1.3
 jupyter-tree-download==1.0.1


### PR DESCRIPTION
- A bunch of extensions are now using the new python based
  extension system! We stop using npm to install these.
- datahub: install the plotly jupyterlab extension, which doesn't seem
  to have been installed earlier.