### PR TITLE
Make R hub use datahub image

### DIFF
--- a/deployments/r/hubploy.yaml
+++ b/deployments/r/hubploy.yaml
@@ -1,5 +1,7 @@
 images:
-  image_name: gcr.io/ucb-datahub-2018/r-user-image
+  images:
+    - name: gcr.io/ucb-datahub-2018/primary-user-image
+      path: ../datahub/images/default
   registry:
     provider: gcloud
     gcloud:


### PR DESCRIPTION
Follow-up to https://github.com/berkeley-dsep-infra/datahub/pull/2046.
Pulls the plug on the existing rocker based R image, and uses
the same image as datahub. Everything present in the R image *should*
be present in this image too.

Fingers crossed!