### PR TITLE
Fix R hub config

### DIFF
--- a/deployments/datahub/images/default/Dockerfile
+++ b/deployments/datahub/images/default/Dockerfile
@@ -105,6 +105,11 @@ RUN curl --silent --location --fail ${RSTUDIO_URL} > /tmp/rstudio.deb && \
     dpkg -i /tmp/rstudio.deb && \
     rm /tmp/rstudio.deb
 
+ENV SHINY_SERVER_URL https://download3.rstudio.org/ubuntu-14.04/x86_64/shiny-server-1.5.15.953-amd64.deb
+RUN curl --silent --location --fail ${SHINY_SERVER_URL} > /tmp/shiny-server.deb && \
+    dpkg -i /tmp/shiny-server.deb && \
+    rm /tmp/shiny-server.deb
+
 # Set CRAN mirror to rspm before we install anything
 COPY Rprofile.site /usr/lib/R/etc/Rprofile.site
 # RStudio needs its own config

--- a/deployments/datahub/images/default/requirements.txt
+++ b/deployments/datahub/images/default/requirements.txt
@@ -12,6 +12,7 @@ folium==0.11
 # r
 jupyter-server-proxy==1.5.0
 jupyter-rsession-proxy==1.2
+jupyter-shiny-proxy==1.1
 #
 # cogsci88;
 ggplot==0.11.5

--- a/deployments/datahub/images/default/requirements.txt
+++ b/deployments/datahub/images/default/requirements.txt
@@ -156,3 +156,6 @@ habanero==0.7.4
 
 # https://github.com/berkeley-dsep-infra/datahub/issues/1981
 ipycanvas==0.7.0
+
+# Issue #1222, for PH 142 - Spring 2020
+PyPDF2==1.26.0

--- a/deployments/r/config/common.yaml
+++ b/deployments/r/config/common.yaml
@@ -29,10 +29,6 @@ jupyterhub:
           mem_guarantee: 1024M
     nodeSelector:
       hub.jupyter.org/pool-name: core-pool
-    extraConfig:
-      # 04, since in hub/values.yaml we explicitly set it to /home/jovyan as 03
-      04-rstudio-home: |
-        c.KubeSpawner.working_dir = '/home/rstudio'
 
   auth:
     type: custom # This enables canvas auth
@@ -63,7 +59,6 @@ jupyterhub:
       hub.jupyter.org/pool-name: gamma-pool
     storage:
       type: static
-      homeMountPath: /home/rstudio
       static:
         pvcName: home-nfs
         subPath: "{username}"
@@ -89,7 +84,7 @@ jupyterhub:
         # only way to change that is by setting $HOME. So instead, we just
         # bind mount a fresh directory on top of ~/.rstudio!
         - name: home
-          mountPath: /home/rstudio/.rstudio
+          mountPath: /home/jovyan/.rstudio
           subPath: '{username}/.r-hub-rstudio'
     defaultUrl: "/rstudio"
     memory:


### PR DESCRIPTION
- R hub used to mount $HOME in /home/rstudio. Mount under /home/jovyan now
- Shiny was installed in the R hub. Install it for datahub too now.
- Install PyPDF2, which someone had wanted on the R hub