### PR TITLE
Add data100 packages to datahub image

### DIFF
--- a/deployments/biology/image/Dockerfile
+++ b/deployments/biology/image/Dockerfile
@@ -157,7 +157,8 @@ COPY requirements.txt /tmp/
 COPY infra-requirements.txt /tmp/
 
 RUN conda env update -p ${CONDA_DIR} -f /tmp/environment.yml
-RUN jupyter contrib nbextension install --sys-prefix
+RUN jupyter contrib nbextensions install --sys-prefix --symlink && \
+    jupyter nbextensions_configurator enable --sys-prefix
 
 # Set CRAN mirror to rspm before we install anything
 COPY Rprofile.site /usr/lib/R/etc/Rprofile.site

--- a/deployments/biology/image/infra-requirements.txt
+++ b/deployments/biology/image/infra-requirements.txt
@@ -25,3 +25,4 @@ jupyter-tree-download==1.0.1
 git-credential-helpers==0.2
 # Enough people like this, let's load it in.
 jupyter-contrib-nbextensions==0.5.1
+jupyter_nbextensions_configurator==0.4.1

--- a/deployments/data100/image/Dockerfile
+++ b/deployments/data100/image/Dockerfile
@@ -28,11 +28,11 @@ RUN apt-get update -qq --yes && \
         git \
         htop \
         less \
-        libpq-dev \
         man \
         mc \
         nano \
         openssh-client \
+        libpq-dev \
         postgresql-client \
         screen \
         tar \

--- a/deployments/data100/image/infra-requirements.txt
+++ b/deployments/data100/image/infra-requirements.txt
@@ -25,3 +25,4 @@ jupyter-tree-download==1.0.1
 git-credential-helpers==0.2
 # Enough people like this, let's load it in.
 jupyter-contrib-nbextensions==0.5.1
+jupyter_nbextensions_configurator==0.4.1

--- a/deployments/data102/image/environment.yml
+++ b/deployments/data102/image/environment.yml
@@ -2,7 +2,8 @@ name: data102
 
 channels:
 - defaults
-
+# dask, distiributed & keras, plotly express
+#
 dependencies:
   - beautifulsoup4=4.7.1
   - bokeh=1.3.2

--- a/deployments/data102/image/infra-requirements.txt
+++ b/deployments/data102/image/infra-requirements.txt
@@ -25,3 +25,4 @@ jupyter-tree-download==1.0.1
 git-credential-helpers==0.2
 # Enough people like this, let's load it in.
 jupyter-contrib-nbextensions==0.5.1
+jupyter_nbextensions_configurator==0.4.1

--- a/deployments/data8x/image/infra-requirements.txt
+++ b/deployments/data8x/image/infra-requirements.txt
@@ -25,3 +25,4 @@ jupyter-tree-download==1.0.1
 git-credential-helpers==0.2
 # Enough people like this, let's load it in.
 jupyter-contrib-nbextensions==0.5.1
+jupyter_nbextensions_configurator==0.4.1

--- a/deployments/datahub/images/default/Dockerfile
+++ b/deployments/datahub/images/default/Dockerfile
@@ -33,13 +33,15 @@ RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && \
 # for nbconvert
 # FIXME: Understand what exactly we want
 # texlive-plain-generic is new name of texlive-generic-recommended
-RUN apt-get -qq install --yes \
+RUN apt-get update > /dev/null && \
+    apt-get -qq install --yes \
             pandoc \
             texlive-xetex \
             texlive-fonts-recommended \
             texlive-plain-generic > /dev/null
 
-RUN apt-get -qq install --yes \
+RUN apt-get update > /dev/null && \
+    apt-get -qq install --yes \
             # for LS88-5 and modules basemap
             libspatialindex-dev \
             # for cartopy
@@ -52,7 +54,10 @@ RUN apt-get -qq install --yes \
             # for phys 151
             gfortran \
             # for eps 109; fall 2019
-            ffmpeg > /dev/null
+            ffmpeg  \
+            # for data100
+            libpq-dev \
+            postgresql-client > /dev/null
 
 # Install packages needed by notebook-as-pdf
 # Default fonts seem ok, we just install an emoji font
@@ -179,7 +184,8 @@ RUN conda env update -p ${CONDA_DIR} -f /tmp/environment.yml
 
 COPY infra-requirements.txt /tmp/infra-requirements.txt
 RUN pip install --no-cache -r /tmp/infra-requirements.txt
-RUN jupyter contrib nbextension install --sys-prefix
+RUN jupyter contrib nbextensions install --sys-prefix --symlink && \
+    jupyter nbextensions_configurator enable --sys-prefix
 
 # Install jupyterlab extensions immediately after infra-requirements
 # This hopefully prevents re-installation all the time

--- a/deployments/datahub/images/default/infra-requirements.txt
+++ b/deployments/datahub/images/default/infra-requirements.txt
@@ -25,3 +25,4 @@ jupyter-tree-download==1.0.1
 git-credential-helpers==0.2
 # Enough people like this, let's load it in.
 jupyter-contrib-nbextensions==0.5.1
+jupyter_nbextensions_configurator==0.4.1

--- a/deployments/datahub/images/default/requirements.txt
+++ b/deployments/datahub/images/default/requirements.txt
@@ -159,3 +159,22 @@ ipycanvas==0.7.0
 
 # Issue #1222, for PH 142 - Spring 2020
 PyPDF2==1.26.0
+
+# data100 scientific packages
+ray==1.1.0
+xlrd==2.0.1
+
+# data100 visualization
+colorlover==0.3.0
+cufflinks==0.17.3
+altair==4.1.0
+
+# data100 tools to access things
+tweepy==3.10.0
+pytz==2020.5
+psycopg2==2.8.6
+
+# data100 teaching
+jassign==0.0.7
+dsassign==0.0.8
+notetaker==0.0.6

--- a/deployments/eecs/image/infra-requirements.txt
+++ b/deployments/eecs/image/infra-requirements.txt
@@ -25,3 +25,4 @@ jupyter-tree-download==1.0.1
 git-credential-helpers==0.2
 # Enough people like this, let's load it in.
 jupyter-contrib-nbextensions==0.5.1
+jupyter_nbextensions_configurator==0.4.1

--- a/deployments/eecs/image/postBuild
+++ b/deployments/eecs/image/postBuild
@@ -10,4 +10,5 @@ jupyter labextension install \
     @jupyter-widgets/jupyterlab-manager \
     @jupyterlab/server-proxy
 
-jupyter contrib nbextension install --sys-prefix
+jupyter contrib nbextensions install --sys-prefix --symlink
+jupyter nbextensions_configurator enable --sys-prefix

--- a/deployments/highschool/image/infra-requirements.txt
+++ b/deployments/highschool/image/infra-requirements.txt
@@ -25,3 +25,4 @@ jupyter-tree-download==1.0.1
 git-credential-helpers==0.2
 # Enough people like this, let's load it in.
 jupyter-contrib-nbextensions==0.5.1
+jupyter_nbextensions_configurator==0.4.1

--- a/deployments/julia/image/Dockerfile
+++ b/deployments/julia/image/Dockerfile
@@ -47,7 +47,8 @@ RUN conda env update -p ${CONDA_DIR}  -f /tmp/environment.yml
 
 COPY infra-requirements.txt /tmp/infra-requirements.txt
 RUN pip install --no-cache -r /tmp/infra-requirements.txt
-RUN jupyter contrib nbextension install --sys-prefix
+RUN jupyter contrib nbextensions install --sys-prefix --symlink && \
+    jupyter nbextensions_configurator enable --sys-prefix
 
 COPY requirements.txt /tmp/requirements.txt
 RUN pip install --no-cache -r /tmp/requirements.txt

--- a/deployments/julia/image/infra-requirements.txt
+++ b/deployments/julia/image/infra-requirements.txt
@@ -25,3 +25,4 @@ jupyter-tree-download==1.0.1
 git-credential-helpers==0.2
 # Enough people like this, let's load it in.
 jupyter-contrib-nbextensions==0.5.1
+jupyter_nbextensions_configurator==0.4.1

--- a/deployments/prob140/image/infra-requirements.txt
+++ b/deployments/prob140/image/infra-requirements.txt
@@ -25,3 +25,4 @@ jupyter-tree-download==1.0.1
 git-credential-helpers==0.2
 # Enough people like this, let's load it in.
 jupyter-contrib-nbextensions==0.5.1
+jupyter_nbextensions_configurator==0.4.1

--- a/deployments/r/image/infra-requirements.txt
+++ b/deployments/r/image/infra-requirements.txt
@@ -25,3 +25,4 @@ jupyter-tree-download==1.0.1
 git-credential-helpers==0.2
 # Enough people like this, let's load it in.
 jupyter-contrib-nbextensions==0.5.1
+jupyter_nbextensions_configurator==0.4.1

--- a/deployments/stat159/image/infra-requirements.txt
+++ b/deployments/stat159/image/infra-requirements.txt
@@ -25,3 +25,4 @@ jupyter-tree-download==1.0.1
 git-credential-helpers==0.2
 # Enough people like this, let's load it in.
 jupyter-contrib-nbextensions==0.5.1
+jupyter_nbextensions_configurator==0.4.1

--- a/deployments/stat89a/image/infra-requirements.txt
+++ b/deployments/stat89a/image/infra-requirements.txt
@@ -25,3 +25,4 @@ jupyter-tree-download==1.0.1
 git-credential-helpers==0.2
 # Enough people like this, let's load it in.
 jupyter-contrib-nbextensions==0.5.1
+jupyter_nbextensions_configurator==0.4.1

--- a/deployments/template/{{cookiecutter.hub_name}}/image/infra-requirements.txt
+++ b/deployments/template/{{cookiecutter.hub_name}}/image/infra-requirements.txt
@@ -25,3 +25,4 @@ jupyter-tree-download==1.0.1
 git-credential-helpers==0.2
 # Enough people like this, let's load it in.
 jupyter-contrib-nbextensions==0.5.1
+jupyter_nbextensions_configurator==0.4.1

--- a/scripts/infra-packages/requirements.txt
+++ b/scripts/infra-packages/requirements.txt
@@ -25,3 +25,4 @@ jupyter-tree-download==1.0.1
 git-credential-helpers==0.2
 # Enough people like this, let's load it in.
 jupyter-contrib-nbextensions==0.5.1
+jupyter_nbextensions_configurator==0.4.1


### PR DESCRIPTION
Let's move data100 to the datahub image. data100 hub is
primarily to limit admin access. Using the same image reduces
our maintenance burden. We couldn't do this early on because
the datahub image did not use conda. It does now.

Installs the jupyter_nbextensions_configurator on all hubs
as well, since it was in the data100 hub. Seems generally
useful.