### PR TITLE
Make data102 use datahub image

### DIFF
--- a/deployments/data102/hubploy.yaml
+++ b/deployments/data102/hubploy.yaml
@@ -1,5 +1,7 @@
 images:
-  image_name: gcr.io/ucb-datahub-2018/data102-user-image
+  images:
+    - name: gcr.io/ucb-datahub-2018/primary-user-image
+      path: ../datahub/images/default
 
   registry:
     provider: gcloud


### PR DESCRIPTION
Missed in the previous round of cleanup