### PR TITLE
Install jupyter-gmaps extension properly

### DIFF
--- a/deployments/datahub/images/default/Dockerfile
+++ b/deployments/datahub/images/default/Dockerfile
@@ -226,10 +226,6 @@ RUN /usr/local/sbin/connector-text.bash
 
 COPY connectors/sw282.bash /usr/local/sbin/connector-sw282.bash
 RUN /usr/local/sbin/connector-sw282.bash
-
-COPY connectors/2019-fall-phys-188-288.bash /usr/local/sbin/
-RUN /usr/local/sbin/2019-fall-phys-188-288.bash
-
 ADD ipython_config.py ${IPYTHONDIR}/ipython_config.py
 
 # install gmaps notebook extension

--- a/deployments/datahub/images/default/Dockerfile
+++ b/deployments/datahub/images/default/Dockerfile
@@ -187,6 +187,12 @@ RUN pip install --no-cache -r /tmp/infra-requirements.txt
 RUN jupyter contrib nbextensions install --sys-prefix --symlink && \
     jupyter nbextensions_configurator enable --sys-prefix
 
+# ls 88-4, economic development connector
+# Should be installed before jupyterlab build, since that's how the
+# lab extension seems to be distributed.
+# See https://github.com/pbugnion/gmaps/issues/349
+RUN pip install --no-cache gmaps==0.9.0
+
 # Install jupyterlab extensions immediately after infra-requirements
 # This hopefully prevents re-installation all the time
 # `jlpm` calls out to yarn internally, and we tell it to

--- a/deployments/datahub/images/default/connectors/2019-fall-phys-188-288.bash
+++ b/deployments/datahub/images/default/connectors/2019-fall-phys-188-288.bash
@@ -1,8 +1,0 @@
-#!/bin/bash
-set -euo pipefail
-
-cd ${CONDA_DIR}
-git clone https://github.com/HerculesJack/assignment-1910
-cd assignment-1910
-bash install.sh
-rm -rf assignment-1910

--- a/deployments/datahub/images/default/requirements.txt
+++ b/deployments/datahub/images/default/requirements.txt
@@ -52,10 +52,7 @@ pillow==8.1.0
 numexpr==2.7.1
 openpyxl==3.0.4
 nilearn==0.6.2
-#
-# ls 88-4, economic development connector
-gmaps==0.9.0
-#
+
 # phys 151;
 emcee==3.0.2
 daft==0.1.0


### PR DESCRIPTION
- Needs an explicit 'build' step after installation. However,
  installing any labextension calls this step, so we can
  just move the pip install to be before our labextensions install.
  This sorts things out :)
- Remove phys 188 packages from datahub image. It was contributing a 
  lot to image build times, since it was compiling things that link to numpy.
  I couldn't find any evidence of phy 188 nor
  phy 288 offered in spring 2021 on classes.berkeley.edu,
  so am removing them.
