### PR TITLE
Unpin nbconvert & nbformat

### DIFF
--- a/deployments/biology/image/infra-requirements.txt
+++ b/deployments/biology/image/infra-requirements.txt
@@ -11,8 +11,6 @@
 # FIXME: Automate finding out when there are new versions of these
 # Temporary until https://github.com/jupyter/notebook/pull/5870 is released
 git+https://github.com/jupyter/notebook@5a73a8e4026ccc8d7437f788bf0bc2758a73567d
-nbconvert==5.6.1
-nbformat==5.0.7
 jupyterlab==3.0.5
 nbgitpuller==0.9.0
 jupyter-resource-usage==0.5.1

--- a/deployments/data8x/image/infra-requirements.txt
+++ b/deployments/data8x/image/infra-requirements.txt
@@ -11,8 +11,6 @@
 # FIXME: Automate finding out when there are new versions of these
 # Temporary until https://github.com/jupyter/notebook/pull/5870 is released
 git+https://github.com/jupyter/notebook@5a73a8e4026ccc8d7437f788bf0bc2758a73567d
-nbconvert==5.6.1
-nbformat==5.0.7
 jupyterlab==3.0.5
 nbgitpuller==0.9.0
 jupyter-resource-usage==0.5.1

--- a/deployments/datahub/images/default/infra-requirements.txt
+++ b/deployments/datahub/images/default/infra-requirements.txt
@@ -11,8 +11,6 @@
 # FIXME: Automate finding out when there are new versions of these
 # Temporary until https://github.com/jupyter/notebook/pull/5870 is released
 git+https://github.com/jupyter/notebook@5a73a8e4026ccc8d7437f788bf0bc2758a73567d
-nbconvert==5.6.1
-nbformat==5.0.7
 jupyterlab==3.0.5
 nbgitpuller==0.9.0
 jupyter-resource-usage==0.5.1

--- a/deployments/dlab/image/infra-requirements.txt
+++ b/deployments/dlab/image/infra-requirements.txt
@@ -11,8 +11,6 @@
 # FIXME: Automate finding out when there are new versions of these
 # Temporary until https://github.com/jupyter/notebook/pull/5870 is released
 git+https://github.com/jupyter/notebook@5a73a8e4026ccc8d7437f788bf0bc2758a73567d
-nbconvert==5.6.1
-nbformat==5.0.7
 jupyterlab==3.0.5
 nbgitpuller==0.9.0
 jupyter-resource-usage==0.5.1
@@ -20,7 +18,7 @@ jupyterhub==1.3.0
 appmode==0.8.0
 ipywidgets==7.6.3
 notebook-as-pdf==0.3.1
-otter-grader==2.0.7
+otter-grader==2.1.0
 jupyter-tree-download==1.0.1
 git-credential-helpers==0.2
 # Enough people like this, let's load it in.

--- a/deployments/eecs/image/infra-requirements.txt
+++ b/deployments/eecs/image/infra-requirements.txt
@@ -11,8 +11,6 @@
 # FIXME: Automate finding out when there are new versions of these
 # Temporary until https://github.com/jupyter/notebook/pull/5870 is released
 git+https://github.com/jupyter/notebook@5a73a8e4026ccc8d7437f788bf0bc2758a73567d
-nbconvert==5.6.1
-nbformat==5.0.7
 jupyterlab==3.0.5
 nbgitpuller==0.9.0
 jupyter-resource-usage==0.5.1

--- a/deployments/julia/image/infra-requirements.txt
+++ b/deployments/julia/image/infra-requirements.txt
@@ -11,8 +11,6 @@
 # FIXME: Automate finding out when there are new versions of these
 # Temporary until https://github.com/jupyter/notebook/pull/5870 is released
 git+https://github.com/jupyter/notebook@5a73a8e4026ccc8d7437f788bf0bc2758a73567d
-nbconvert==5.6.1
-nbformat==5.0.7
 jupyterlab==3.0.5
 nbgitpuller==0.9.0
 jupyter-resource-usage==0.5.1

--- a/deployments/r/image/infra-requirements.txt
+++ b/deployments/r/image/infra-requirements.txt
@@ -11,8 +11,6 @@
 # FIXME: Automate finding out when there are new versions of these
 # Temporary until https://github.com/jupyter/notebook/pull/5870 is released
 git+https://github.com/jupyter/notebook@5a73a8e4026ccc8d7437f788bf0bc2758a73567d
-nbconvert==5.6.1
-nbformat==5.0.7
 jupyterlab==3.0.5
 nbgitpuller==0.9.0
 jupyter-resource-usage==0.5.1

--- a/deployments/template/{{cookiecutter.hub_name}}/image/infra-requirements.txt
+++ b/deployments/template/{{cookiecutter.hub_name}}/image/infra-requirements.txt
@@ -11,8 +11,6 @@
 # FIXME: Automate finding out when there are new versions of these
 # Temporary until https://github.com/jupyter/notebook/pull/5870 is released
 git+https://github.com/jupyter/notebook@5a73a8e4026ccc8d7437f788bf0bc2758a73567d
-nbconvert==5.6.1
-nbformat==5.0.7
 jupyterlab==3.0.5
 nbgitpuller==0.9.0
 jupyter-resource-usage==0.5.1

--- a/scripts/infra-packages/requirements.txt
+++ b/scripts/infra-packages/requirements.txt
@@ -11,8 +11,6 @@
 # FIXME: Automate finding out when there are new versions of these
 # Temporary until https://github.com/jupyter/notebook/pull/5870 is released
 git+https://github.com/jupyter/notebook@5a73a8e4026ccc8d7437f788bf0bc2758a73567d
-nbconvert==5.6.1
-nbformat==5.0.7
 jupyterlab==3.0.5
 nbgitpuller==0.9.0
 jupyter-resource-usage==0.5.1


### PR DESCRIPTION
nbconvert has moved pretty far ahead (6.x),
and we're running into PDF generation errors again
that are probably fixed via newer nbconvert.