### PR TITLE
Update nbconvert again

### DIFF
--- a/deployments/biology/image/infra-requirements.txt
+++ b/deployments/biology/image/infra-requirements.txt
@@ -13,7 +13,8 @@
 git+https://github.com/jupyter/notebook@5a73a8e4026ccc8d7437f788bf0bc2758a73567d
 # Brings in https://github.com/jupyter/nbconvert/pull/1513
 # Brings in https://github.com/jupyter/nbconvert/pull/1515
-git+https://github.com/yuvipanda/nbconvert@e9b62f6a6515069243fc158f88b80978452ee9cd
+# Brings in https://github.com/jupyter/nbconvert/pull/1516
+git+https://github.com/yuvipanda/nbconvert@b141b2b15c1bdf3f3ad64125fb9ebcce90922984
 jupyterlab==3.0.5
 nbgitpuller==0.9.0
 jupyter-resource-usage==0.5.1

--- a/deployments/biology/image/infra-requirements.txt
+++ b/deployments/biology/image/infra-requirements.txt
@@ -11,10 +11,6 @@
 # FIXME: Automate finding out when there are new versions of these
 # Temporary until https://github.com/jupyter/notebook/pull/5870 is released
 git+https://github.com/jupyter/notebook@5a73a8e4026ccc8d7437f788bf0bc2758a73567d
-# Brings in https://github.com/jupyter/nbconvert/pull/1513
-# Brings in https://github.com/jupyter/nbconvert/pull/1515
-# Brings in https://github.com/jupyter/nbconvert/pull/1516
-git+https://github.com/yuvipanda/nbconvert@b141b2b15c1bdf3f3ad64125fb9ebcce90922984
 jupyterlab==3.0.5
 nbgitpuller==0.9.0
 jupyter-resource-usage==0.5.1

--- a/deployments/data8x/image/infra-requirements.txt
+++ b/deployments/data8x/image/infra-requirements.txt
@@ -13,7 +13,8 @@
 git+https://github.com/jupyter/notebook@5a73a8e4026ccc8d7437f788bf0bc2758a73567d
 # Brings in https://github.com/jupyter/nbconvert/pull/1513
 # Brings in https://github.com/jupyter/nbconvert/pull/1515
-git+https://github.com/yuvipanda/nbconvert@e9b62f6a6515069243fc158f88b80978452ee9cd
+# Brings in https://github.com/jupyter/nbconvert/pull/1516
+git+https://github.com/yuvipanda/nbconvert@b141b2b15c1bdf3f3ad64125fb9ebcce90922984
 jupyterlab==3.0.5
 nbgitpuller==0.9.0
 jupyter-resource-usage==0.5.1

--- a/deployments/data8x/image/infra-requirements.txt
+++ b/deployments/data8x/image/infra-requirements.txt
@@ -11,10 +11,6 @@
 # FIXME: Automate finding out when there are new versions of these
 # Temporary until https://github.com/jupyter/notebook/pull/5870 is released
 git+https://github.com/jupyter/notebook@5a73a8e4026ccc8d7437f788bf0bc2758a73567d
-# Brings in https://github.com/jupyter/nbconvert/pull/1513
-# Brings in https://github.com/jupyter/nbconvert/pull/1515
-# Brings in https://github.com/jupyter/nbconvert/pull/1516
-git+https://github.com/yuvipanda/nbconvert@b141b2b15c1bdf3f3ad64125fb9ebcce90922984
 jupyterlab==3.0.5
 nbgitpuller==0.9.0
 jupyter-resource-usage==0.5.1

--- a/deployments/datahub/images/default/Dockerfile
+++ b/deployments/datahub/images/default/Dockerfile
@@ -190,8 +190,7 @@ RUN r /tmp/r-packages/2021-spring-espm-288.r
 
 ENV PATH ${CONDA_DIR}/bin:$PATH:/usr/lib/rstudio-server/bin
 
-# Set this to be on container storage, rather than under $HOME
-ENV IPYTHONDIR ${CONDA_DIR}/etc/ipython
+# Set this to be on container storage, rather than under $HOME ENV IPYTHONDIR ${CONDA_DIR}/etc/ipython
 
 WORKDIR /home/${NB_USER}
 
@@ -211,6 +210,7 @@ COPY infra-requirements.txt /tmp/infra-requirements.txt
 RUN pip install --no-cache -r /tmp/infra-requirements.txt
 RUN jupyter contrib nbextensions install --sys-prefix --symlink && \
     jupyter nbextensions_configurator enable --sys-prefix
+
 
 # Install jupyterlab extensions immediately after infra-requirements
 # This hopefully prevents re-installation all the time
@@ -254,3 +254,12 @@ RUN jupyter nbextension enable --py --sys-prefix qgrid
 
 
 EXPOSE 8888
+
+# Temporarily install new nbconvert version to fix pagination in PDF generation
+# This can't be in infra-requirements, since that seems to just install the
+# published versions of nbconvert from notebook. Adding this to the end of the
+# image so we can experiment with this faster.
+# Brings in https://github.com/jupyter/nbconvert/pull/1513
+# Brings in https://github.com/jupyter/nbconvert/pull/1515
+# Brings in https://github.com/jupyter/nbconvert/pull/1516
+RUN pip install --no-cache git+https://github.com/yuvipanda/nbconvert@888f39b9fe131f8af403a9396538996afbfd7aa2

--- a/deployments/datahub/images/default/infra-requirements.txt
+++ b/deployments/datahub/images/default/infra-requirements.txt
@@ -13,7 +13,8 @@
 git+https://github.com/jupyter/notebook@5a73a8e4026ccc8d7437f788bf0bc2758a73567d
 # Brings in https://github.com/jupyter/nbconvert/pull/1513
 # Brings in https://github.com/jupyter/nbconvert/pull/1515
-git+https://github.com/yuvipanda/nbconvert@e9b62f6a6515069243fc158f88b80978452ee9cd
+# Brings in https://github.com/jupyter/nbconvert/pull/1516
+git+https://github.com/yuvipanda/nbconvert@b141b2b15c1bdf3f3ad64125fb9ebcce90922984
 jupyterlab==3.0.5
 nbgitpuller==0.9.0
 jupyter-resource-usage==0.5.1

--- a/deployments/datahub/images/default/infra-requirements.txt
+++ b/deployments/datahub/images/default/infra-requirements.txt
@@ -11,10 +11,6 @@
 # FIXME: Automate finding out when there are new versions of these
 # Temporary until https://github.com/jupyter/notebook/pull/5870 is released
 git+https://github.com/jupyter/notebook@5a73a8e4026ccc8d7437f788bf0bc2758a73567d
-# Brings in https://github.com/jupyter/nbconvert/pull/1513
-# Brings in https://github.com/jupyter/nbconvert/pull/1515
-# Brings in https://github.com/jupyter/nbconvert/pull/1516
-git+https://github.com/yuvipanda/nbconvert@b141b2b15c1bdf3f3ad64125fb9ebcce90922984
 jupyterlab==3.0.5
 nbgitpuller==0.9.0
 jupyter-resource-usage==0.5.1

--- a/deployments/dlab/image/infra-requirements.txt
+++ b/deployments/dlab/image/infra-requirements.txt
@@ -13,7 +13,8 @@
 git+https://github.com/jupyter/notebook@5a73a8e4026ccc8d7437f788bf0bc2758a73567d
 # Brings in https://github.com/jupyter/nbconvert/pull/1513
 # Brings in https://github.com/jupyter/nbconvert/pull/1515
-git+https://github.com/yuvipanda/nbconvert@e9b62f6a6515069243fc158f88b80978452ee9cd
+# Brings in https://github.com/jupyter/nbconvert/pull/1516
+git+https://github.com/yuvipanda/nbconvert@b141b2b15c1bdf3f3ad64125fb9ebcce90922984
 jupyterlab==3.0.5
 nbgitpuller==0.9.0
 jupyter-resource-usage==0.5.1

--- a/deployments/dlab/image/infra-requirements.txt
+++ b/deployments/dlab/image/infra-requirements.txt
@@ -11,10 +11,6 @@
 # FIXME: Automate finding out when there are new versions of these
 # Temporary until https://github.com/jupyter/notebook/pull/5870 is released
 git+https://github.com/jupyter/notebook@5a73a8e4026ccc8d7437f788bf0bc2758a73567d
-# Brings in https://github.com/jupyter/nbconvert/pull/1513
-# Brings in https://github.com/jupyter/nbconvert/pull/1515
-# Brings in https://github.com/jupyter/nbconvert/pull/1516
-git+https://github.com/yuvipanda/nbconvert@b141b2b15c1bdf3f3ad64125fb9ebcce90922984
 jupyterlab==3.0.5
 nbgitpuller==0.9.0
 jupyter-resource-usage==0.5.1

--- a/deployments/eecs/image/infra-requirements.txt
+++ b/deployments/eecs/image/infra-requirements.txt
@@ -13,7 +13,8 @@
 git+https://github.com/jupyter/notebook@5a73a8e4026ccc8d7437f788bf0bc2758a73567d
 # Brings in https://github.com/jupyter/nbconvert/pull/1513
 # Brings in https://github.com/jupyter/nbconvert/pull/1515
-git+https://github.com/yuvipanda/nbconvert@e9b62f6a6515069243fc158f88b80978452ee9cd
+# Brings in https://github.com/jupyter/nbconvert/pull/1516
+git+https://github.com/yuvipanda/nbconvert@b141b2b15c1bdf3f3ad64125fb9ebcce90922984
 jupyterlab==3.0.5
 nbgitpuller==0.9.0
 jupyter-resource-usage==0.5.1

--- a/deployments/eecs/image/infra-requirements.txt
+++ b/deployments/eecs/image/infra-requirements.txt
@@ -11,10 +11,6 @@
 # FIXME: Automate finding out when there are new versions of these
 # Temporary until https://github.com/jupyter/notebook/pull/5870 is released
 git+https://github.com/jupyter/notebook@5a73a8e4026ccc8d7437f788bf0bc2758a73567d
-# Brings in https://github.com/jupyter/nbconvert/pull/1513
-# Brings in https://github.com/jupyter/nbconvert/pull/1515
-# Brings in https://github.com/jupyter/nbconvert/pull/1516
-git+https://github.com/yuvipanda/nbconvert@b141b2b15c1bdf3f3ad64125fb9ebcce90922984
 jupyterlab==3.0.5
 nbgitpuller==0.9.0
 jupyter-resource-usage==0.5.1

--- a/deployments/julia/image/infra-requirements.txt
+++ b/deployments/julia/image/infra-requirements.txt
@@ -13,7 +13,8 @@
 git+https://github.com/jupyter/notebook@5a73a8e4026ccc8d7437f788bf0bc2758a73567d
 # Brings in https://github.com/jupyter/nbconvert/pull/1513
 # Brings in https://github.com/jupyter/nbconvert/pull/1515
-git+https://github.com/yuvipanda/nbconvert@e9b62f6a6515069243fc158f88b80978452ee9cd
+# Brings in https://github.com/jupyter/nbconvert/pull/1516
+git+https://github.com/yuvipanda/nbconvert@b141b2b15c1bdf3f3ad64125fb9ebcce90922984
 jupyterlab==3.0.5
 nbgitpuller==0.9.0
 jupyter-resource-usage==0.5.1

--- a/deployments/julia/image/infra-requirements.txt
+++ b/deployments/julia/image/infra-requirements.txt
@@ -11,10 +11,6 @@
 # FIXME: Automate finding out when there are new versions of these
 # Temporary until https://github.com/jupyter/notebook/pull/5870 is released
 git+https://github.com/jupyter/notebook@5a73a8e4026ccc8d7437f788bf0bc2758a73567d
-# Brings in https://github.com/jupyter/nbconvert/pull/1513
-# Brings in https://github.com/jupyter/nbconvert/pull/1515
-# Brings in https://github.com/jupyter/nbconvert/pull/1516
-git+https://github.com/yuvipanda/nbconvert@b141b2b15c1bdf3f3ad64125fb9ebcce90922984
 jupyterlab==3.0.5
 nbgitpuller==0.9.0
 jupyter-resource-usage==0.5.1

--- a/deployments/r/image/infra-requirements.txt
+++ b/deployments/r/image/infra-requirements.txt
@@ -13,7 +13,8 @@
 git+https://github.com/jupyter/notebook@5a73a8e4026ccc8d7437f788bf0bc2758a73567d
 # Brings in https://github.com/jupyter/nbconvert/pull/1513
 # Brings in https://github.com/jupyter/nbconvert/pull/1515
-git+https://github.com/yuvipanda/nbconvert@e9b62f6a6515069243fc158f88b80978452ee9cd
+# Brings in https://github.com/jupyter/nbconvert/pull/1516
+git+https://github.com/yuvipanda/nbconvert@b141b2b15c1bdf3f3ad64125fb9ebcce90922984
 jupyterlab==3.0.5
 nbgitpuller==0.9.0
 jupyter-resource-usage==0.5.1

--- a/deployments/r/image/infra-requirements.txt
+++ b/deployments/r/image/infra-requirements.txt
@@ -11,10 +11,6 @@
 # FIXME: Automate finding out when there are new versions of these
 # Temporary until https://github.com/jupyter/notebook/pull/5870 is released
 git+https://github.com/jupyter/notebook@5a73a8e4026ccc8d7437f788bf0bc2758a73567d
-# Brings in https://github.com/jupyter/nbconvert/pull/1513
-# Brings in https://github.com/jupyter/nbconvert/pull/1515
-# Brings in https://github.com/jupyter/nbconvert/pull/1516
-git+https://github.com/yuvipanda/nbconvert@b141b2b15c1bdf3f3ad64125fb9ebcce90922984
 jupyterlab==3.0.5
 nbgitpuller==0.9.0
 jupyter-resource-usage==0.5.1

--- a/deployments/template/{{cookiecutter.hub_name}}/image/infra-requirements.txt
+++ b/deployments/template/{{cookiecutter.hub_name}}/image/infra-requirements.txt
@@ -13,7 +13,8 @@
 git+https://github.com/jupyter/notebook@5a73a8e4026ccc8d7437f788bf0bc2758a73567d
 # Brings in https://github.com/jupyter/nbconvert/pull/1513
 # Brings in https://github.com/jupyter/nbconvert/pull/1515
-git+https://github.com/yuvipanda/nbconvert@e9b62f6a6515069243fc158f88b80978452ee9cd
+# Brings in https://github.com/jupyter/nbconvert/pull/1516
+git+https://github.com/yuvipanda/nbconvert@b141b2b15c1bdf3f3ad64125fb9ebcce90922984
 jupyterlab==3.0.5
 nbgitpuller==0.9.0
 jupyter-resource-usage==0.5.1

--- a/deployments/template/{{cookiecutter.hub_name}}/image/infra-requirements.txt
+++ b/deployments/template/{{cookiecutter.hub_name}}/image/infra-requirements.txt
@@ -11,10 +11,6 @@
 # FIXME: Automate finding out when there are new versions of these
 # Temporary until https://github.com/jupyter/notebook/pull/5870 is released
 git+https://github.com/jupyter/notebook@5a73a8e4026ccc8d7437f788bf0bc2758a73567d
-# Brings in https://github.com/jupyter/nbconvert/pull/1513
-# Brings in https://github.com/jupyter/nbconvert/pull/1515
-# Brings in https://github.com/jupyter/nbconvert/pull/1516
-git+https://github.com/yuvipanda/nbconvert@b141b2b15c1bdf3f3ad64125fb9ebcce90922984
 jupyterlab==3.0.5
 nbgitpuller==0.9.0
 jupyter-resource-usage==0.5.1

--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -31,6 +31,8 @@ etcJupyter:
       shutdown_no_activity_timeout: 3600
     ResourceUseDisplay:
       disable_legacy_endpoint: true
+    WebPDFExporter:
+      disable_sandbox: true
 
 etcGitConfig:
   enabled: false

--- a/scripts/infra-packages/requirements.txt
+++ b/scripts/infra-packages/requirements.txt
@@ -13,7 +13,8 @@
 git+https://github.com/jupyter/notebook@5a73a8e4026ccc8d7437f788bf0bc2758a73567d
 # Brings in https://github.com/jupyter/nbconvert/pull/1513
 # Brings in https://github.com/jupyter/nbconvert/pull/1515
-git+https://github.com/yuvipanda/nbconvert@e9b62f6a6515069243fc158f88b80978452ee9cd
+# Brings in https://github.com/jupyter/nbconvert/pull/1516
+git+https://github.com/yuvipanda/nbconvert@b141b2b15c1bdf3f3ad64125fb9ebcce90922984
 jupyterlab==3.0.5
 nbgitpuller==0.9.0
 jupyter-resource-usage==0.5.1

--- a/scripts/infra-packages/requirements.txt
+++ b/scripts/infra-packages/requirements.txt
@@ -11,10 +11,6 @@
 # FIXME: Automate finding out when there are new versions of these
 # Temporary until https://github.com/jupyter/notebook/pull/5870 is released
 git+https://github.com/jupyter/notebook@5a73a8e4026ccc8d7437f788bf0bc2758a73567d
-# Brings in https://github.com/jupyter/nbconvert/pull/1513
-# Brings in https://github.com/jupyter/nbconvert/pull/1515
-# Brings in https://github.com/jupyter/nbconvert/pull/1516
-git+https://github.com/yuvipanda/nbconvert@b141b2b15c1bdf3f3ad64125fb9ebcce90922984
 jupyterlab==3.0.5
 nbgitpuller==0.9.0
 jupyter-resource-usage==0.5.1


### PR DESCRIPTION
Brings in https://github.com/jupyter/nbconvert/pull/1516

In infra-requirements.txt, the nbconvert (~6.x) we get
from being a notebook package dependency seems to take
precedence over our explicit requirement. So, we put this
in the end of the Dockerfile instead - forces the install,
and makes it easier to iterate.
