### PR TITLE
Remove modules specific shared storage

### DIFF
--- a/deployments/datahub/config/common.yaml
+++ b/deployments/datahub/config/common.yaml
@@ -67,25 +67,6 @@ jupyterhub:
         2020-spring-25995:
           mem_limit: 4096M
           mem_guarantee: 1024M
-        modules-leads:
-          users:
-            - yuvipanda
-            - ktakimoto
-            - ericvd
-            - jasonjiang
-            - alec.kan
-            - eesaravia
-            - almapineda
-            - m.wilkinson
-            - schaganty
-            - timlan.wong
-          extraVolumes:
-            - name: shared
-              hostPath:
-                path: /data/homes/prod/_shared/module-leads
-          extraVolumeMounts:
-            - name: shared
-              mountPath: /home/jovyan/shared/module-leads
   proxy:
     nodeSelector:
       hub.jupyter.org/pool-name: core-pool


### PR DESCRIPTION
This hasn't been working at all since we moved
to mounting NFS via PVC. When moving to COS based
images, the root filesystem is readonl - so this
causes the container to fail.