### PR TITLE
Update node-pool creation command

### DIFF
--- a/docs/admins/cluster-config.rst
+++ b/docs/admins/cluster-config.rst
@@ -32,8 +32,8 @@ the currently favored configuration.
         --enable-autoscaling \
         --max-nodes=20 --min-nodes=1 \
         --region=us-central1 --node-locations=us-central1-b \
-        --image-type=ubuntu \
-        --disk-size=100 --disk-type=pd-standard \
+        --image-type=cos \
+        --disk-size=100 --disk-type=pd-balanced \
         --machine-type=n1-highmem-8 \
         --cluster-version latest \
         --no-enable-autoupgrade \
@@ -49,11 +49,11 @@ the currently favored configuration.
         --num-nodes 2 \
         --enable-autoscaling \
         --min-nodes 1 --max-nodes 20 \
-        --node-labels hub.jupyter.org/pool-name=<pool-name>-pool \
+        --node-labels hub.jupyter.org/pool-name=beta-pool \
         --node-taints hub.jupyter.org_dedicated=user:NoSchedule \
         --region=us-central1 \
-        --image-type=ubuntu \
-        --disk-size=200 --disk-type=pd-ssd \
+        --image-type=cos \
+        --disk-size=200 --disk-type=pd-balanced \
         --no-enable-autoupgrade \
         --tags=hub-cluster \
         --cluster=fall-2019 \
@@ -115,12 +115,6 @@ There are regions closer to us, but latency hasn't really mattered so we are
 currently still in us-central1. There are also unsubstantiated rumors that us-central1 is their
 biggest data center and hence less likely to run out of quota.
 
-Ubuntu operating system
------------------------
-
-Since we use :ref:`NFS for user home directories <topic/storage>`, we select
-Ubuntu as our `node operating system <https://cloud.google.com/kubernetes-engine/docs/concepts/node-images>`_.
-The default (Container Optimized OS) does not have NFS support enabled.
 
 Disk Size
 ---------
@@ -135,7 +129,8 @@ of big images, or if we want our image pulls to be faster (since disk performanc
 
 ``--disk-type=pd-standard`` gives us standard spinning disks, which are cheaper. We
 can also request SSDs instead with ``--disk-type=pd-ssd`` - it is much faster,
-but also much more expensive.
+but also much more expensive. We compromise with ``--disk-type=pd-balanced``, faster
+than spinning disks but not as fast as ssds all the time.
 
 Node size
 ---------


### PR DESCRIPTION
- We now use Container Optimized OS instead of Ubuntu for
  base images. This is far more locked down & secure than
  the Ubuntu base image, but used to not support NFS mounts.
  It now does, so we can switch to it - see #2024
- We use Balanced SSDs for all disk base images, rather than
  SSDs. This is cheaper (0.1 per GB rather than 0.17 per GB),
  and should hopefully provide enough image pulling performance
  for us. If not, we can always move back.
- I've also moved the alpha & beta pool to use the newer configuration.
  I'll move gamma in a day or two if things go well.

Closes #2024