### PR TITLE
Bump ESPM 288 RAM

### DIFF
--- a/deployments/r/config/common.yaml
+++ b/deployments/r/config/common.yaml
@@ -27,6 +27,11 @@ jupyterhub:
         2020-fall-27267:
           mem_limit: 4096M
           mem_guarantee: 1024M
+        # espm 288 - https://github.com/berkeley-dsep-infra/datahub/issues/2137
+        # Big limit OK since they only have 12 students
+        2021-spring-27769:
+          mem_limit: 8192M
+          mem_guarantee: 4096M
     nodeSelector:
       hub.jupyter.org/pool-name: core-pool
 


### PR DESCRIPTION
8G is higher than we usually go, but it's only
12 students so it's ok.

Fixes #2137