### PR TITLE
Install nginx-ingress + cert-manager

### DIFF
--- a/support/requirements.yaml
+++ b/support/requirements.yaml
@@ -5,4 +5,9 @@ dependencies:
  - name: grafana
    version: 6.2.1
    repository: https://grafana.github.io/helm-charts
-#   repository: https://kubernetes-charts.storage.googleapis.com
+ - name: cert-manager
+   version: v1.1.0
+   repository: https://charts.jetstack.io
+ - name: ingress-nginx
+   version: 3.23.0
+   repository: https://kubernetes.github.io/ingress-nginx

--- a/support/values.yaml
+++ b/support/values.yaml
@@ -1,3 +1,12 @@
+cert-manager:
+  installCRDs: true
+ingress-nginx:
+  controller:
+    service:
+      loadBalancerIP: 34.69.164.86
+    podLabels:
+      hub.jupyter.org/network-access-proxy-http: 'true'
+
 prometheus:
   # We were using network tags to restrict NFS access to just nodes from hub-cluster
   # However, it turns out packets coming from *pods* are *not* tagged with that, just from the nodes!
@@ -47,19 +56,32 @@ prometheus:
       type: ClusterIP
 
 grafana:
-  persistence:
-    storageClassName: standard
   deploymentStrategy:
     type: Recreate
 
   persistence:
     enabled: true
+    storageClassName: standard
+
   service:
-    type: LoadBalancer
+    type: ClusterIP
+
+  ingress:
+    enabled: true
+    annotations:
+      kubernetes.io/ingress.class: nginx
+      cert-manager.io/cluster-issuer: letsencrypt-prod
+    hosts:
+      - grafana.datahub.berkeley.edu
+    tls:
+    - hosts:
+      - grafana.datahub.berkeley.edu
+      secretName: grafana-https-auto-tls
 
   grafana.ini:
     server:
-      root_url: http://grafana.datahub.berkeley.edu/
+      root_url: https://grafana.datahub.berkeley.edu/
+
   datasources:
     datasources.yaml:
       apiVersion: 1


### PR DESCRIPTION
- Setup https for grafana - I discovered that my current ISP
  is MITMing and injecting ad-fraud malware into http requests lol.
- Pave the way for using ingresses for *all* hubs in the future.
  I've setup a wildcard DNS entry for the nginx-ingress loadbalancer
  IP. In the future, we can vastly simplif new hub setup with this.