### PR TITLE
Get traffic into cs194 staging hub with ingresses

### DIFF
--- a/deployments/cs194/config/staging.yaml
+++ b/deployments/cs194/config/staging.yaml
@@ -13,9 +13,11 @@ jupyterhub:
       config:
         client_id: '10720000000000471'
         oauth_callback_url: 'https://cs194-staging.datahub.berkeley.edu/hub/oauth_callback'
-  proxy:
-    service:
-      loadBalancerIP: 35.222.77.133
-    https:
-      hosts:
-        - cs194-staging.datahub.berkeley.edu
+  ingress:
+    enabled: true
+    hosts:
+      - cs194-staging.datahub.berkeley.edu
+    tls:
+      - secretName: tls-cert
+        hosts:
+          - cs194-staging.datahub.berkeley.edu

--- a/hub/requirements.yaml
+++ b/hub/requirements.yaml
@@ -3,6 +3,9 @@ dependencies:
    # REMEMBER TO CHANGE BASE IMAGE OF images/hub/ WHEN CHANGING THIS
    version: 0.10.0
    repository: https://jupyterhub.github.io/helm-chart/
+ # - name: jupyterhub-ssh
+ #   version: 0.0.1
+ #   repository: file://../../jupyterhub-ssh/helm-chart/jupyterhub-ssh
  - name: jupyterhub-ssh
-   version: 0.0.1-n062.h2759fb4
+   version: 0.0.1-n077.h0c9caba
    repository: https://yuvipanda.github.io/jupyterhub-ssh/

--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -40,11 +40,41 @@ nfsPVC:
   enabled: true
 
 jupyterhub-ssh:
+  ssh:
+    networkPolicy:
+      ingress:
+        - ports:
+            - port: ssh
+              protocol: TCP
+          from:
+            - namespaceSelector:
+                matchLabels:
+                  name: support
+              podSelector:
+                matchLabels:
+                  hub.jupyter.org/network-access-ssh-server: "true"
   sftp:
+    networkPolicy:
+      ingress:
+        - ports:
+            - port: sftp
+              protocol: TCP
+          from:
+            - namespaceSelector:
+                matchLabels:
+                  name: support
+              podSelector:
+                matchLabels:
+                  hub.jupyter.org/network-access-ssh-server: "true"
     pvc:
       name: home-nfs
 
 jupyterhub:
+  ingress:
+    annotations:
+      nginx.ingress.kubernetes.io/proxy-body-size: 256m
+      kubernetes.io/ingress.class: nginx
+      cert-manager.io/cluster-issuer: letsencrypt-prod
   scheduling:
     podPriority:
       enabled: true

--- a/support/values.yaml
+++ b/support/values.yaml
@@ -1,11 +1,23 @@
 cert-manager:
   installCRDs: true
 ingress-nginx:
+  tcp:
+    # We need to manually allocate a port for ssh & sftp for
+    # each hub. We have a wildcard for *.datahub.berkeley.edu,
+    # and SSH doesn't have host-based routing. So we differentiate
+    # different hubs by assigning ports for ssh & sftp to each one.
+    # This should be a part of new hub creation.
+
+    # cs194-staging
+    22222: cs194-staging/jupyterhub-ssh:22
+    22223: cs194-staging/jupyterhub-sftp:22
   controller:
     service:
       loadBalancerIP: 34.69.164.86
     podLabels:
       hub.jupyter.org/network-access-proxy-http: 'true'
+      hub.jupyter.org/network-access-ssh-server: "true"
+      hub.jupyter.org/network-access-sftp-server: "true"
 
 prometheus:
   # We were using network tags to restrict NFS access to just nodes from hub-cluster


### PR DESCRIPTION
- Remove the explicit DNS entry for cs194-staging,
  so the wildcard entry resolves it to our nginx-ingress.
- Setup ingress config for cs194-staging, so HTTPS is autogenerated.
- Manually allocate SSH / SFTP ports for cs194-staging.
  nginx-ingress will proxy incoming ssh connections to the correct
  hub based on the ports folks are connecting via.
- jupyterhub-ssh helm chart bump so we can allow traffic from
  nginx-ingress via networkpolicy

I'll deploy manually to a few hubs, and slowly roll it out
across all the hubs.

Ref #2167