### PR TITLE
Use ingress to get traffic into dlab hub

### DIFF
--- a/deployments/dlab/config/prod.yaml
+++ b/deployments/dlab/config/prod.yaml
@@ -2,12 +2,14 @@ jupyterhub-ssh:
   hubUrl: https://dlab.datahub.berkeley.edu
 
 jupyterhub:
-  proxy:
-    service:
-      loadBalancerIP: 34.122.240.224
-    https:
-      hosts:
-        - dlab.datahub.berkeley.edu
+  ingress:
+    enabled: true
+    hosts:
+      - dlab.datahub.berkeley.edu
+    tls:
+      - secretName: tls-cert
+        hosts:
+          - dlab.datahub.berkeley.edu
   hub:
     db:
       pvc:

--- a/deployments/dlab/config/staging.yaml
+++ b/deployments/dlab/config/staging.yaml
@@ -8,9 +8,11 @@ jupyterhub:
   prePuller:
     continuous:
       enabled: false
-  proxy:
-    service:
-      loadBalancerIP: 35.232.137.1
-    https:
-      hosts:
-        - dlab-staging.datahub.berkeley.edu
+  ingress:
+    enabled: true
+    hosts:
+      - dlab-staging.datahub.berkeley.edu
+    tls:
+      - secretName: tls-cert
+        hosts:
+          - dlab-staging.datahub.berkeley.edu

--- a/support/values.yaml
+++ b/support/values.yaml
@@ -18,6 +18,14 @@ ingress-nginx:
     # stat159
     22003: stat159-prod/jupyterhub-ssh:22
     22004: stat159-prod/jupyterhub-sftp:22
+
+    # dlab-staging
+    22005: dlab-staging/jupyterhub-ssh:22
+    22006: dlab-staging/jupyterhub-sftp:22
+    # stat159
+    22007: dlab-prod/jupyterhub-ssh:22
+    22008: dlab-prod/jupyterhub-sftp:22
+
   controller:
     # Best effort guess on resource needs
     # We overprovision a little - issues here cause a full cluster outage


### PR DESCRIPTION
Ref #2167

I've removed the A records pointing to the
LoadBalancer IPs.