### PR TITLE
Don't build images when deploying to prod

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -354,7 +354,6 @@ workflows:
               branches:
                 only:
                 - staging
-                - prod
       - hubploy/build-image:
           deployment: biology
           name: biology image build
@@ -364,7 +363,6 @@ workflows:
               branches:
                 only:
                 - staging
-                - prod
       - hubploy/build-image:
           deployment: julia
           name: julia hub image build
@@ -374,7 +372,6 @@ workflows:
               branches:
                 only:
                 - staging
-                - prod
       - hubploy/build-image:
           deployment: data8x
           name: data8x image build
@@ -384,7 +381,6 @@ workflows:
               branches:
                 only:
                 - staging
-                - prod
       - hubploy/build-image:
           deployment: eecs
           name: eecs image build
@@ -394,7 +390,10 @@ workflows:
               branches:
                 only:
                 - staging
-                - prod
+      # Build images only during the staging deploy. All merges
+      # to prod need to go via staging, so prod should *never*
+      # use images not built for staging. By enforcing this at the
+      # CI level, we also make prod deploys go faster!
       - deploy:
           requires:
               - datahub image build
@@ -406,6 +405,10 @@ workflows:
             branches:
               only:
                 - staging
+      - deploy:
+          filters:
+            branches:
+              only:
                 - prod
   deploy-support:
     jobs:


### PR DESCRIPTION
We have a github action that makes sure that only
staging branch can be merged to prod. This means
that prod will never need to build images, since
staging would have already built and deployed them.