### PR TITLE
Add micro text editor to default image

### DIFF
--- a/deployments/datahub/images/default/Dockerfile
+++ b/deployments/datahub/images/default/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get -qq update --yes && \
     apt-get -qq install --yes \
             tar \
             vim \
+            micro \
             locales > /dev/null
 
 RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && \


### PR DESCRIPTION
Adds the `micro` command-line text editor as a default, that should be friendlier than vim to newcomers who find themselves in a text editor unexpectedly (such as when making a git commit).

I looked around a lot and [micro](https://github.com/zyedidia/micro) seems like a great way of providing simplicity and ease of use at the command line.  It does what folks new to the CLI are more likely to expect from a text editor (shift-arrow highlight,` `C-x,c,v` for cut/copy/paste, `C-q` for quitting, etc). 

We often find newcomers getting dropped into vim from e.g. a git commit operation, and it can be very jarring. If teaching the CLI in-depth isn't part of a course's goals, this can be an unwelcome distraction/source of confusion.

We're making improvements to JupyterLab to ease this with its own GUI tools, but I think having a super-friendly/familiar editor as a baseline at the CLI for scenarios where teaching vim/emacs isn't viable would be great.

cc @pbstark @Dmacracy in case they have further thoughts.