### PR TITLE
Add midnight commander (mc) package for better remote file management.

### DIFF
--- a/deployments/datahub/images/default/Dockerfile
+++ b/deployments/datahub/images/default/Dockerfile
@@ -26,6 +26,7 @@ RUN apt-get -qq update --yes && \
             tar \
             vim \
             micro \
+            mc \
             locales > /dev/null
 
 RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && \


### PR DESCRIPTION
mc is a very powerful, yet still command-line-based file manager. Having it
available by default will make it easier for students to do more complex file
operations on the hub than by purely issuing unix commands.