### PR TITLE
Move r hub to use ingress

### DIFF
--- a/deployments/r/config/common.yaml
+++ b/deployments/r/config/common.yaml
@@ -17,6 +17,8 @@ jupyterhub:
       nodeSelector:
         hub.jupyter.org/pool-name: core-pool
   proxy:
+    service:
+      type: ClusterIP
     nodeSelector:
       hub.jupyter.org/pool-name: core-pool
   hub:

--- a/deployments/r/config/prod.yaml
+++ b/deployments/r/config/prod.yaml
@@ -2,12 +2,14 @@ jupyterhub-ssh:
   hubUrl: https://r.datahub.berkeley.edu
 
 jupyterhub:
-  proxy:
-    service:
-      loadBalancerIP: 34.68.2.114
-    https:
-      hosts:
-        - r.datahub.berkeley.edu
+  ingress:
+    enabled: true
+    hosts:
+      - r.datahub.berkeley.edu
+    tls:
+      - secretName: tls-cert
+        hosts:
+          - r.datahub.berkeley.edu
   hub:
     db:
       pvc:

--- a/deployments/r/config/staging.yaml
+++ b/deployments/r/config/staging.yaml
@@ -8,9 +8,11 @@ jupyterhub:
   prePuller:
     continuous:
       enabled: false
-  proxy:
-    service:
-      loadBalancerIP: 34.68.107.18
-    https:
-      hosts:
-        - r-staging.datahub.berkeley.edu
+  ingress:
+    enabled: true
+    hosts:
+      - r-staging.datahub.berkeley.edu
+    tls:
+      - secretName: tls-cert
+        hosts:
+          - r-staging.datahub.berkeley.edu

--- a/support/values.yaml
+++ b/support/values.yaml
@@ -1,20 +1,15 @@
 cert-manager:
   installCRDs: true
+  # Our cluster-internal DNS seems to cache aggressively in
+  # some cases. The cache is also more likely to be warm,
+  # causing issues when cert-manager tries to verify
+  # that the ACME http-01 challenge will succeed. Since
+  # Let's encrypt itself isn't going to use our cluster-local
+  # DNS, this causes false negatives - cert-manager thinks the
+  # challenge will fail, but in reality it will most likely not.
+  podDnsPolicy: None
   podDnsConfig:
     nameservers:
-      # Our cluster-internal DNS seems to cache aggressively in
-      # some cases. The cache is also more likely to be warm,
-      # causing issues when cert-manager tries to verify
-      # that the ACME http-01 challenge will succeed. Since
-      # Let's encrypt itself isn't going to use our cluster-local
-      # DNS, this causes false negatives - cert-manager thinks the
-      # challenge will fail, but in reality it might not.
-      # Ideally, there would be an option that lets us force
-      # cert-manager to ignore caches and hit the upstream nameserver
-      # directly. For now though, this works well enough.
-      # I haven't actually verified if cert-manager checks if the
-      # challenge will succeed before starting it - I am guessing
-      # based on behavior observed. Hopefully this helps?
       - 1.1.1.1
       - 8.8.8.8
 ingress-nginx:


### PR DESCRIPTION
Ref #2167

Explicitly ignore cluster-local DNS server for
cert-manager.