### PR TITLE
Disable subdomain enforcement with HSTS

### DIFF
--- a/support/values.yaml
+++ b/support/values.yaml
@@ -59,6 +59,10 @@ ingress-nginx:
     22019: workshop-prod/jupyterhub-ssh:22
     22020: workshop-prod/jupyterhub-sftp:22
   controller:
+    config:
+      # Let's preserve ability to have HTTP pages served under *.datahub.berkeley.edu
+      # when necessary. Ideally would not be, but I want to preserve that option.
+      hsts-include-subdomains: "false"
     # Best effort guess on resource needs
     # We overprovision a little - issues here cause a full cluster outage
     replicaCount: 2


### PR DESCRIPTION
I do not want to commit to *.datahub.berkeley.edu
being just HTTPS forever. While it's true now, and I'd like
it to be true in the future, setting includeSubDomains
binds our hands. I'd like to not do that.