### PR TITLE
Small un/reinstall hack to get PyMC3 working

### DIFF
--- a/deployments/datahub/images/default/Dockerfile
+++ b/deployments/datahub/images/default/Dockerfile
@@ -236,9 +236,10 @@ RUN pip install --no-cache -r /tmp/requirements.txt
 # Hack to get PyMC3 working for Data 102 & Astro 128/256
 # These are the same versions as in requirements.txt, but
 # the import fails unless you uninstall and reinstall
+# See https://github.com/berkeley-dsep-infra/datahub/issues/2207
 RUN pip uninstall Theano Theano-PyMC pymc3 -y
-RUN pip install 'Theano==1.0.5'
-RUN pip install 'pymc3==3.11.0'
+RUN pip install --no-cache 'Theano==1.0.5'
+RUN pip install --no-cache 'pymc3==3.11.0'
 
 # Set up nbpdf dependencies
 ENV PYPPETEER_HOME ${CONDA_DIR}

--- a/deployments/datahub/images/default/Dockerfile
+++ b/deployments/datahub/images/default/Dockerfile
@@ -233,6 +233,13 @@ RUN pip install --no-cache numpy==1.19.5 cython==0.29.21
 COPY requirements.txt /tmp/requirements.txt
 RUN pip install --no-cache -r /tmp/requirements.txt
 
+# Hack to get PyMC3 working for Data 102 & Astro 128/256
+# These are the same versions as in requirements.txt, but
+# the import fails unless you uninstall and reinstall
+RUN pip uninstall Theano Theano-PyMC pymc3 -y
+RUN pip install 'Theano==1.0.5'
+RUN pip install 'pymc3==3.11.0'
+
 # Set up nbpdf dependencies
 ENV PYPPETEER_HOME ${CONDA_DIR}
 RUN pyppeteer-install


### PR DESCRIPTION
The fixes in #2200 still led to new errors. Running these commands in a notebook and then restarting the python kernel seemed to fix it, so I'm adding the commands to the Dockerfile for now.