### PR TITLE
Mark most proxy-public services as ClusterIP

### DIFF
--- a/deployments/cs194/config/prod.yaml
+++ b/deployments/cs194/config/prod.yaml
@@ -3,6 +3,7 @@ jupyterhub-ssh:
 
 jupyterhub:
   proxy:
+    type: Loadbalancer
     service:
       loadBalancerIP: 35.193.57.206
     https:

--- a/deployments/data8x/config/common.yaml
+++ b/deployments/data8x/config/common.yaml
@@ -9,6 +9,8 @@ jupyterhub:
     services:
       gofer_nb:
         url: http://35.239.20.122:10101
+  proxy:
+    type: Loadbalancer
   auth:
     type: lti
     admin:

--- a/deployments/datahub/config/common.yaml
+++ b/deployments/datahub/config/common.yaml
@@ -68,6 +68,7 @@ jupyterhub:
           mem_limit: 4096M
           mem_guarantee: 1024M
   proxy:
+    type: Loadbalancer
     nodeSelector:
       hub.jupyter.org/pool-name: core-pool
   auth:

--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -93,6 +93,7 @@ jupyterhub:
           memory: 1G
   proxy:
     service:
+      type: ClusterIP
       extraPorts:
         - port: 22
           targetPort: 8022


### PR DESCRIPTION
We wanna release our unused static IP addresses,
since all traffic into most hubs now comes in
via the ingress controller. The exceptions are
the data8x hubs, cs194 prod and the datahubs. We
explicitly mark those as LoadBalancer to keep their
public IPs intact. I've already removed their DNS
entries.


You can't actually just change the type from
LoadBalancer to ClusterIP (https://github.com/kubernetes/kubectl/issues/221),
so this command was used to patch them manually
k get ns | rg staging | rg -v datahub | awk '{ print $1; }' | xargs -L1 -I{} kubectl -n {} patch svc proxy-public --type='json' -p '[{"op":"replace","path":"/spec/type","value":"ClusterIP"},{"op":"replace","path":"/spec/ports/0/nodePort","value":null},{"op":"replace","path":"/spec/ports/1/nodePort","value":null},{"op":"replace","path":"/spec/ports/2/nodePort","value":null}]'


Ref #2167