### PR TITLE
Install lfe R package

### DIFF
--- a/deployments/datahub/images/default/install.R
+++ b/deployments/datahub/images/default/install.R
@@ -187,8 +187,9 @@ cran_packages = c(
   "xfun", "0.19",
   "xml2", "1.3.2",
   "xts", "0.12.1",
-  "yaml", "2.2.1"
-  ## "lfe", "???" # https://github.com/sgaure/lfe/issues/41
+  "yaml", "2.2.1",
+  # For https://github.com/berkeley-dsep-infra/datahub/issues/2239
+  "lfe", "2.8-6"
   )
 
 class_libs_install_version("Base packages", cran_packages)


### PR DESCRIPTION
https://github.com/sgaure/lfe/issues/41 seems to be
resolved, since the package is now on CRAN and can
be installed. I had removed it during the image migration
since it had been taken off CRAN.

Fixes #2239