### PR TITLE
Update numpy to 1.20.1 and add numpydoc.

### DIFF
--- a/deployments/datahub/images/default/Dockerfile
+++ b/deployments/datahub/images/default/Dockerfile
@@ -231,7 +231,7 @@ RUN jlpm cache dir && mkdir -p /tmp/yarncache && \
         @jupyterlab/geojson-extension && \
     rm -rf /tmp/yarncache
 
-RUN pip install --no-cache numpy==1.19.5 cython==0.29.21
+RUN pip install --no-cache numpy==1.20.1 cython==0.29.21
 
 COPY requirements.txt /tmp/requirements.txt
 RUN pip install --no-cache -r /tmp/requirements.txt

--- a/deployments/datahub/images/default/requirements.txt
+++ b/deployments/datahub/images/default/requirements.txt
@@ -195,6 +195,7 @@ cryptorandom==0.2
 git+https://github.com/statlab/permute@v0.1.a5
 pycodestyle==2.6.0
 pep257==0.7.0
+numpydoc==1.1.0
 
 # cs194 2021 Spring
 ipython-sql==0.4.0


### PR DESCRIPTION
I'm a little worried about changing the main numpy version for others, but for stat159 it turns out we need it, as cryptorandom (which we're working with extensively) has bumped its dependencies to 1.20.x...

I hope it's possible to make this change only for our s159 hub, without any impact/disruption on any of the other hubs...