### PR TITLE
Bump JupyterLab & notebook versions

### DIFF
--- a/deployments/biology/image/infra-requirements.txt
+++ b/deployments/biology/image/infra-requirements.txt
@@ -8,16 +8,14 @@
 # everwhere one by one.
 
 # FIXME: Freeze this to get exact versions of all dependencies
-# FIXME: Automate finding out when there are new versions of these
-# Temporary until https://github.com/jupyter/notebook/pull/5870 is released
-git+https://github.com/jupyter/notebook@5a73a8e4026ccc8d7437f788bf0bc2758a73567d
+notebook==6.2.0
 # from @chrispyles
 # i see that nbformat was unpinned. since the pin, because of the new cell id
 # parameter in notebook format v4 the notebook validation is failing whenever
 # someone opens a notebook created w/ nbformat>=5.1.0. is it possible to pin
 # below 5.1.0 while notebook patches this?
 nbformat<5.1.0
-jupyterlab==3.0.5
+jupyterlab==3.0.11
 nbgitpuller==0.9.0
 jupyter-resource-usage==0.5.1
 jupyterhub==1.3.0

--- a/deployments/data8x/image/infra-requirements.txt
+++ b/deployments/data8x/image/infra-requirements.txt
@@ -8,16 +8,14 @@
 # everwhere one by one.
 
 # FIXME: Freeze this to get exact versions of all dependencies
-# FIXME: Automate finding out when there are new versions of these
-# Temporary until https://github.com/jupyter/notebook/pull/5870 is released
-git+https://github.com/jupyter/notebook@5a73a8e4026ccc8d7437f788bf0bc2758a73567d
+notebook==6.2.0
 # from @chrispyles
 # i see that nbformat was unpinned. since the pin, because of the new cell id
 # parameter in notebook format v4 the notebook validation is failing whenever
 # someone opens a notebook created w/ nbformat>=5.1.0. is it possible to pin
 # below 5.1.0 while notebook patches this?
 nbformat<5.1.0
-jupyterlab==3.0.5
+jupyterlab==3.0.11
 nbgitpuller==0.9.0
 jupyter-resource-usage==0.5.1
 jupyterhub==1.3.0

--- a/deployments/datahub/images/default/infra-requirements.txt
+++ b/deployments/datahub/images/default/infra-requirements.txt
@@ -8,16 +8,14 @@
 # everwhere one by one.
 
 # FIXME: Freeze this to get exact versions of all dependencies
-# FIXME: Automate finding out when there are new versions of these
-# Temporary until https://github.com/jupyter/notebook/pull/5870 is released
-git+https://github.com/jupyter/notebook@5a73a8e4026ccc8d7437f788bf0bc2758a73567d
+notebook==6.2.0
 # from @chrispyles
 # i see that nbformat was unpinned. since the pin, because of the new cell id
 # parameter in notebook format v4 the notebook validation is failing whenever
 # someone opens a notebook created w/ nbformat>=5.1.0. is it possible to pin
 # below 5.1.0 while notebook patches this?
 nbformat<5.1.0
-jupyterlab==3.0.5
+jupyterlab==3.0.11
 nbgitpuller==0.9.0
 jupyter-resource-usage==0.5.1
 jupyterhub==1.3.0

--- a/deployments/dlab/image/infra-requirements.txt
+++ b/deployments/dlab/image/infra-requirements.txt
@@ -8,16 +8,14 @@
 # everwhere one by one.
 
 # FIXME: Freeze this to get exact versions of all dependencies
-# FIXME: Automate finding out when there are new versions of these
-# Temporary until https://github.com/jupyter/notebook/pull/5870 is released
-git+https://github.com/jupyter/notebook@5a73a8e4026ccc8d7437f788bf0bc2758a73567d
+notebook==6.2.0
 # from @chrispyles
 # i see that nbformat was unpinned. since the pin, because of the new cell id
 # parameter in notebook format v4 the notebook validation is failing whenever
 # someone opens a notebook created w/ nbformat>=5.1.0. is it possible to pin
 # below 5.1.0 while notebook patches this?
 nbformat<5.1.0
-jupyterlab==3.0.5
+jupyterlab==3.0.11
 nbgitpuller==0.9.0
 jupyter-resource-usage==0.5.1
 jupyterhub==1.3.0

--- a/deployments/eecs/image/infra-requirements.txt
+++ b/deployments/eecs/image/infra-requirements.txt
@@ -8,16 +8,14 @@
 # everwhere one by one.
 
 # FIXME: Freeze this to get exact versions of all dependencies
-# FIXME: Automate finding out when there are new versions of these
-# Temporary until https://github.com/jupyter/notebook/pull/5870 is released
-git+https://github.com/jupyter/notebook@5a73a8e4026ccc8d7437f788bf0bc2758a73567d
+notebook==6.2.0
 # from @chrispyles
 # i see that nbformat was unpinned. since the pin, because of the new cell id
 # parameter in notebook format v4 the notebook validation is failing whenever
 # someone opens a notebook created w/ nbformat>=5.1.0. is it possible to pin
 # below 5.1.0 while notebook patches this?
 nbformat<5.1.0
-jupyterlab==3.0.5
+jupyterlab==3.0.11
 nbgitpuller==0.9.0
 jupyter-resource-usage==0.5.1
 jupyterhub==1.3.0

--- a/deployments/julia/image/infra-requirements.txt
+++ b/deployments/julia/image/infra-requirements.txt
@@ -8,16 +8,14 @@
 # everwhere one by one.
 
 # FIXME: Freeze this to get exact versions of all dependencies
-# FIXME: Automate finding out when there are new versions of these
-# Temporary until https://github.com/jupyter/notebook/pull/5870 is released
-git+https://github.com/jupyter/notebook@5a73a8e4026ccc8d7437f788bf0bc2758a73567d
+notebook==6.2.0
 # from @chrispyles
 # i see that nbformat was unpinned. since the pin, because of the new cell id
 # parameter in notebook format v4 the notebook validation is failing whenever
 # someone opens a notebook created w/ nbformat>=5.1.0. is it possible to pin
 # below 5.1.0 while notebook patches this?
 nbformat<5.1.0
-jupyterlab==3.0.5
+jupyterlab==3.0.11
 nbgitpuller==0.9.0
 jupyter-resource-usage==0.5.1
 jupyterhub==1.3.0

--- a/deployments/r/image/infra-requirements.txt
+++ b/deployments/r/image/infra-requirements.txt
@@ -8,16 +8,14 @@
 # everwhere one by one.
 
 # FIXME: Freeze this to get exact versions of all dependencies
-# FIXME: Automate finding out when there are new versions of these
-# Temporary until https://github.com/jupyter/notebook/pull/5870 is released
-git+https://github.com/jupyter/notebook@5a73a8e4026ccc8d7437f788bf0bc2758a73567d
+notebook==6.2.0
 # from @chrispyles
 # i see that nbformat was unpinned. since the pin, because of the new cell id
 # parameter in notebook format v4 the notebook validation is failing whenever
 # someone opens a notebook created w/ nbformat>=5.1.0. is it possible to pin
 # below 5.1.0 while notebook patches this?
 nbformat<5.1.0
-jupyterlab==3.0.5
+jupyterlab==3.0.11
 nbgitpuller==0.9.0
 jupyter-resource-usage==0.5.1
 jupyterhub==1.3.0

--- a/deployments/template/{{cookiecutter.hub_name}}/image/infra-requirements.txt
+++ b/deployments/template/{{cookiecutter.hub_name}}/image/infra-requirements.txt
@@ -8,16 +8,14 @@
 # everwhere one by one.
 
 # FIXME: Freeze this to get exact versions of all dependencies
-# FIXME: Automate finding out when there are new versions of these
-# Temporary until https://github.com/jupyter/notebook/pull/5870 is released
-git+https://github.com/jupyter/notebook@5a73a8e4026ccc8d7437f788bf0bc2758a73567d
+notebook==6.2.0
 # from @chrispyles
 # i see that nbformat was unpinned. since the pin, because of the new cell id
 # parameter in notebook format v4 the notebook validation is failing whenever
 # someone opens a notebook created w/ nbformat>=5.1.0. is it possible to pin
 # below 5.1.0 while notebook patches this?
 nbformat<5.1.0
-jupyterlab==3.0.5
+jupyterlab==3.0.11
 nbgitpuller==0.9.0
 jupyter-resource-usage==0.5.1
 jupyterhub==1.3.0

--- a/scripts/infra-packages/requirements.txt
+++ b/scripts/infra-packages/requirements.txt
@@ -8,16 +8,14 @@
 # everwhere one by one.
 
 # FIXME: Freeze this to get exact versions of all dependencies
-# FIXME: Automate finding out when there are new versions of these
-# Temporary until https://github.com/jupyter/notebook/pull/5870 is released
-git+https://github.com/jupyter/notebook@5a73a8e4026ccc8d7437f788bf0bc2758a73567d
+notebook==6.2.0
 # from @chrispyles
 # i see that nbformat was unpinned. since the pin, because of the new cell id
 # parameter in notebook format v4 the notebook validation is failing whenever
 # someone opens a notebook created w/ nbformat>=5.1.0. is it possible to pin
 # below 5.1.0 while notebook patches this?
 nbformat<5.1.0
-jupyterlab==3.0.5
+jupyterlab==3.0.11
 nbgitpuller==0.9.0
 jupyter-resource-usage==0.5.1
 jupyterhub==1.3.0


### PR DESCRIPTION
https://github.com/jupyter/notebook/pull/5870 has been
merged, and we weren't actually using it anyway.

Ref #2252