### PR TITLE
Install build essential for stat159

### DIFF
--- a/deployments/stat159/image/Dockerfile
+++ b/deployments/stat159/image/Dockerfile
@@ -26,6 +26,7 @@ RUN apt-get -qq update --yes && \
             vim \
             micro \
             mc \
+            build-essential \
             locales > /dev/null
 
 RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && \


### PR DESCRIPTION
Ref https://github.com/berkeley-dsep-infra/datahub/pull/2270

I found make in datahub but not in stat159 :| gcc was in both tho