### PR TITLE
Add lime and shap to requirements for DS102

### DIFF
--- a/deployments/datahub/images/default/requirements.txt
+++ b/deployments/datahub/images/default/requirements.txt
@@ -186,6 +186,8 @@ keras-vis==0.4.1
 plotly-express==0.4.1
 cytoolz==0.11.0
 pyro-ppl==1.5.2
+lime==0.2.0.1
+shap==0.39.0
 
 # prob140 2021 Spring
 prob140==0.4.1.5


### PR DESCRIPTION
We're experimenting with LIME and SHAP for ML explainability in DS102 and would like these packages installed. They seem to install cleanly on datahub, so I don't anticipate any issues coming up (like we had with theano earlier in the semester).