### PR TITLE
Setup mongodb for cs194

### DIFF
--- a/deployments/cs194/config/common.yaml
+++ b/deployments/cs194/config/common.yaml
@@ -32,16 +32,14 @@ jupyterhub:
           - lexyyxl
     extraConfig:
       cs194-01-pvc: |
-        storage_class = 'ssd'
-        storage_capacity = '1G'
         from jupyterhub.utils import exponential_backoff
         from kubespawner.objects import make_pvc
         from functools import partial
 
-        def make_db_pvc(spawner):
+        def make_extra_pvc(component, name_template, storage_class, storage_capacity, spawner):
           labels = spawner._build_common_labels({})
           labels.update({
-              'component': 'db-storage'
+              'component': component
           })
 
           annotations = spawner._build_common_annotations({})
@@ -49,7 +47,7 @@ jupyterhub:
           storage_selector = spawner._expand_all(spawner.storage_selector)
 
           return make_pvc(
-              name=spawner._expand_all('db-{username}'),
+              name=spawner._expand_all(name_template),
               storage_class=storage_class,
               access_modes=['ReadWriteOnce'],
               selector={},
@@ -58,19 +56,24 @@ jupyterhub:
               annotations=annotations
           )
 
+        make_db_pvc = partial(make_extra_pvc, 'db-storage', 'db-{username}', 'ssd', '1G')
+        make_mongo_pvc = partial(make_extra_pvc, 'mongo-storage', 'mongo-{username}', 'standard', '20G')
+
+        pvc_makers = (make_db_pvc, make_mongo_pvc)
         async def ensure_db_pvc(spawner):
           """"
           Ensure a PVC is created for this user's database volume
           """
-          pvc = make_db_pvc(spawner)
+          for pvc_maker in pvc_makers:
+            pvc = pvc_maker(spawner)
 
-          # If there's a timeout, just let it propagate
-          await exponential_backoff(
-              partial(spawner._make_create_pvc_request, pvc, spawner.k8s_api_request_timeout),
-              f'Could not create pvc {pvc.metadata.name}',
-              # Each req should be given k8s_api_request_timeout seconds.
-              timeout=spawner.k8s_api_request_retry_timeout
-          )
+            # If there's a timeout, just let it propagate
+            await exponential_backoff(
+                partial(spawner._make_create_pvc_request, pvc, spawner.k8s_api_request_timeout),
+                f'Could not create pvc {pvc.metadata.name}',
+                # Each req should be given k8s_api_request_timeout seconds.
+                timeout=spawner.k8s_api_request_retry_timeout
+            )
 
         c.Spawner.pre_spawn_hook = ensure_db_pvc
     nodeSelector:
@@ -94,12 +97,17 @@ jupyterhub:
         - name: postgres-db
           persistentVolumeClaim:
             claimName: 'db-{username}'
+        - name: mongodb
+          persistentVolumeClaim:
+            claimName: 'mongo-{username}'
       extraVolumeMounts:
         - name: postgres-db
           mountPath: /var/lib/postgresql/data
           # postgres recommends against mounting a volume directly here
           # So we put data in a subpath
           subPath: data
+        - name: mongodb
+          mountPath: /data/db
     initContainers:
       # /var/lib/postgresql should be writeable by uid 1000, so students
       # can blow out their db directories if need to. Just setting UID on the
@@ -118,6 +126,30 @@ jupyterhub:
           # So we put data in a subpath
           subPath: data
     extraContainers:
+      - name: mongo
+        image: mongo:3.6-xenial
+        args:
+          # We run mongodb without authentication, but only listening on localhost
+          # This matches what we do for postgres
+          - --bind_ip
+          - 127.0.0.1
+        volumeMounts:
+        - name: home
+          mountPath: /home/jovyan
+          subPath: "{username}"
+        - name: mongodb
+          mountPath: /data/db
+        securityContext:
+          runAsUser: 1000
+        resources:
+          limits:
+            # Best effort only. No more than 1 CPU
+            memory: 512Mi
+            cpu: 1.0
+          requests:
+            # If we don't set requests, k8s sets requests == limits!
+            memory: 64Mi
+            cpu: 0.01
       - name: postgres
         image: gcr.io/ucb-datahub-2018/jupyterhub-postgres:0.0.1-n3657.h4f7f88c
         resources:

--- a/deployments/datahub/images/default/Dockerfile
+++ b/deployments/datahub/images/default/Dockerfile
@@ -258,8 +258,6 @@ ENV NLTK_DATA ${CONDA_DIR}/nltk_data
 COPY connectors/text.bash /usr/local/sbin/connector-text.bash
 RUN /usr/local/sbin/connector-text.bash
 
-COPY connectors/sw282.bash /usr/local/sbin/connector-sw282.bash
-RUN /usr/local/sbin/connector-sw282.bash
 ADD ipython_config.py ${IPYTHONDIR}/ipython_config.py
 
 # install QGrid notebook extension

--- a/deployments/datahub/images/default/connectors/sw282.bash
+++ b/deployments/datahub/images/default/connectors/sw282.bash
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-# Issue #929
-
-set -euo pipefail
-
-git clone https://github.com/yuvipanda/gradable-nbexport.git
-cd ~/gradable-nbexport && python setup.py install
-cd ~ && rm -rf gradable-nbexport

--- a/deployments/datahub/images/default/requirements.txt
+++ b/deployments/datahub/images/default/requirements.txt
@@ -1,4 +1,3 @@
-#
 # data8; foundation
 datascience==0.17.0
 matplotlib==3.3.3
@@ -204,3 +203,6 @@ pymongo==3.11.3
 
 # ESPM 167 - https://github.com/berkeley-dsep-infra/datahub/issues/2278
 contextily==1.1.0
+
+# For SW282 - see Issue #929
+git+https://github.com/yuvipanda/gradable-nbexport.git@904e0f6c55446f007f07bc12b2af883fb1cc7aee

--- a/deployments/datahub/images/default/requirements.txt
+++ b/deployments/datahub/images/default/requirements.txt
@@ -200,6 +200,7 @@ pep257==0.7.0
 # cs194 2021 Spring
 ipython-sql==0.4.0
 pgspecial==1.11.10
+pymongo==3.11.3
 
 # ESPM 167 - https://github.com/berkeley-dsep-infra/datahub/issues/2278
 contextily==1.1.0


### PR DESCRIPTION
CS194 is doing a project using nosql databases, and
wants to use mongodb. Similar to how we setup postgres,
we:

- Create a PVC for mongodb, giving it 20G of standard storage.
  We give 1G of SSD to postgres, but the mongo dataset is already
  10G. So we give it more storage, but slower. This should be
  deleted at some point in the near future - will be worked out
  with CS194 staff.
- We use the upstream mongodb docker image, and setup persistent
  data to be in our provisioned volume.
- Install pymongo in our image. We don't provide commandline
  mongodb clients, since they aren't in upstream ubuntu apt
  repos anymore due to licensing issues. I do believe that what
  we are doing here complies with the current mongodb license.