### PR TITLE
Bump datahub hub-dir size to 80Gi

### DIFF
--- a/deployments/datahub/config/prod.yaml
+++ b/deployments/datahub/config/prod.yaml
@@ -12,7 +12,7 @@ jupyterhub:
     db:
       pvc:
         # This also holds logs
-        storage: 40Gi
+        storage: 80Gi
     resources:
       requests:
         # DataHub often takes up a full CPU now, so let's guarantee it at least that


### PR DESCRIPTION
The 40Gi disk was full, causing an outage.

Ref https://github.com/berkeley-dsep-infra/datahub/issues/2242