### PR TITLE
Fix Rprofile.site to point to correct mirror

### DIFF
--- a/deployments/biology/image/Rprofile.site
+++ b/deployments/biology/image/Rprofile.site
@@ -1,6 +1,10 @@
-local({
-    r <- getOption("repos")
-    r["CRAN"] <- "https://packagemanager.rstudio.com/all/__linux__/focal/latest"
-    options(repos = r)
-    options(HTTPUserAgent = sprintf("R/%s R (%s)", getRversion(), paste(getRversion(), R.version$platform, R.version$arch, R.version$os)))
-})
+# Use RStudio's CRAN mirror to get binary packages
+# 'latest' just means it has all available versions.
+# We can specify version numbers in devtools::install_version
+options(repos = c(CRAN = "https://packagemanager.rstudio.com/all/__linux__/focal/latest"))
+
+# RStudio's CRAN mirror needs this to figure out which binary package to serve.
+# If not set properly, it will just serve up source packages
+# Quite hilarious, IMO.
+# See https://docs.rstudio.com/rspm/admin/binaries.html
+options(HTTPUserAgent = sprintf("R/%s R (%s)", getRversion(), paste(getRversion(), R.version$platform, R.version$arch, R.version$os)))

--- a/deployments/biology/image/infra-requirements.txt
+++ b/deployments/biology/image/infra-requirements.txt
@@ -15,6 +15,8 @@ notebook==6.2.0
 # someone opens a notebook created w/ nbformat>=5.1.0. is it possible to pin
 # below 5.1.0 while notebook patches this?
 nbformat<5.1.0
+# Pin for https://github.com/jupyter/jupyter-packaging/issues/81
+setuptools>=56.0
 jupyterlab==3.0.14
 nbgitpuller==0.9.0
 jupyter-resource-usage==0.5.1

--- a/deployments/biology/image/infra-requirements.txt
+++ b/deployments/biology/image/infra-requirements.txt
@@ -15,7 +15,7 @@ notebook==6.2.0
 # someone opens a notebook created w/ nbformat>=5.1.0. is it possible to pin
 # below 5.1.0 while notebook patches this?
 nbformat<5.1.0
-jupyterlab==3.0.11
+jupyterlab==3.0.14
 nbgitpuller==0.9.0
 jupyter-resource-usage==0.5.1
 jupyterhub==1.3.0

--- a/deployments/data8x/image/infra-requirements.txt
+++ b/deployments/data8x/image/infra-requirements.txt
@@ -15,6 +15,8 @@ notebook==6.2.0
 # someone opens a notebook created w/ nbformat>=5.1.0. is it possible to pin
 # below 5.1.0 while notebook patches this?
 nbformat<5.1.0
+# Pin for https://github.com/jupyter/jupyter-packaging/issues/81
+setuptools>=56.0
 jupyterlab==3.0.14
 nbgitpuller==0.9.0
 jupyter-resource-usage==0.5.1

--- a/deployments/data8x/image/infra-requirements.txt
+++ b/deployments/data8x/image/infra-requirements.txt
@@ -15,7 +15,7 @@ notebook==6.2.0
 # someone opens a notebook created w/ nbformat>=5.1.0. is it possible to pin
 # below 5.1.0 while notebook patches this?
 nbformat<5.1.0
-jupyterlab==3.0.11
+jupyterlab==3.0.14
 nbgitpuller==0.9.0
 jupyter-resource-usage==0.5.1
 jupyterhub==1.3.0

--- a/deployments/datahub/images/default/Dockerfile
+++ b/deployments/datahub/images/default/Dockerfile
@@ -228,7 +228,6 @@ RUN jlpm cache dir && mkdir -p /tmp/yarncache && \
     jupyter labextension install --debug \
         @jupyterlab/server-proxy \
         jupyterlab-plotly@4.14.3 plotlywidget@4.14.3 \
-        @jupyterlab/geojson-extension && \
     rm -rf /tmp/yarncache
 
 RUN pip install --no-cache numpy==1.19.5 cython==0.29.21

--- a/deployments/datahub/images/default/Rprofile.site
+++ b/deployments/datahub/images/default/Rprofile.site
@@ -1,6 +1,10 @@
-local({
-    r <- getOption("repos")
-    r["CRAN"] <- "https://packagemanager.rstudio.com/all/__linux__/focal/latest"
-    options(repos = r)
-    options(HTTPUserAgent = sprintf("R/%s R (%s)", getRversion(), paste(getRversion(), R.version$platform, R.version$arch, R.version$os)))
-})
+# Use RStudio's CRAN mirror to get binary packages
+# 'latest' just means it has all available versions.
+# We can specify version numbers in devtools::install_version
+options(repos = c(CRAN = "https://packagemanager.rstudio.com/all/__linux__/focal/latest"))
+
+# RStudio's CRAN mirror needs this to figure out which binary package to serve.
+# If not set properly, it will just serve up source packages
+# Quite hilarious, IMO.
+# See https://docs.rstudio.com/rspm/admin/binaries.html
+options(HTTPUserAgent = sprintf("R/%s R (%s)", getRversion(), paste(getRversion(), R.version$platform, R.version$arch, R.version$os)))

--- a/deployments/datahub/images/default/infra-requirements.txt
+++ b/deployments/datahub/images/default/infra-requirements.txt
@@ -15,6 +15,8 @@ notebook==6.2.0
 # someone opens a notebook created w/ nbformat>=5.1.0. is it possible to pin
 # below 5.1.0 while notebook patches this?
 nbformat<5.1.0
+# Pin for https://github.com/jupyter/jupyter-packaging/issues/81
+setuptools>=56.0
 jupyterlab==3.0.14
 nbgitpuller==0.9.0
 jupyter-resource-usage==0.5.1

--- a/deployments/datahub/images/default/infra-requirements.txt
+++ b/deployments/datahub/images/default/infra-requirements.txt
@@ -15,7 +15,7 @@ notebook==6.2.0
 # someone opens a notebook created w/ nbformat>=5.1.0. is it possible to pin
 # below 5.1.0 while notebook patches this?
 nbformat<5.1.0
-jupyterlab==3.0.11
+jupyterlab==3.0.14
 nbgitpuller==0.9.0
 jupyter-resource-usage==0.5.1
 jupyterhub==1.3.0

--- a/deployments/datahub/images/default/requirements.txt
+++ b/deployments/datahub/images/default/requirements.txt
@@ -205,3 +205,6 @@ pymongo==3.11.3
 
 # ESPM 167 - https://github.com/berkeley-dsep-infra/datahub/issues/2278
 contextily==1.1.0
+
+# JupyterLab pypi extensions
+jupyterlab-geojson==3.1.2

--- a/deployments/dlab/image/infra-requirements.txt
+++ b/deployments/dlab/image/infra-requirements.txt
@@ -15,6 +15,8 @@ notebook==6.2.0
 # someone opens a notebook created w/ nbformat>=5.1.0. is it possible to pin
 # below 5.1.0 while notebook patches this?
 nbformat<5.1.0
+# Pin for https://github.com/jupyter/jupyter-packaging/issues/81
+setuptools>=56.0
 jupyterlab==3.0.14
 nbgitpuller==0.9.0
 jupyter-resource-usage==0.5.1

--- a/deployments/dlab/image/infra-requirements.txt
+++ b/deployments/dlab/image/infra-requirements.txt
@@ -15,7 +15,7 @@ notebook==6.2.0
 # someone opens a notebook created w/ nbformat>=5.1.0. is it possible to pin
 # below 5.1.0 while notebook patches this?
 nbformat<5.1.0
-jupyterlab==3.0.11
+jupyterlab==3.0.14
 nbgitpuller==0.9.0
 jupyter-resource-usage==0.5.1
 jupyterhub==1.3.0

--- a/deployments/eecs/image/infra-requirements.txt
+++ b/deployments/eecs/image/infra-requirements.txt
@@ -15,6 +15,8 @@ notebook==6.2.0
 # someone opens a notebook created w/ nbformat>=5.1.0. is it possible to pin
 # below 5.1.0 while notebook patches this?
 nbformat<5.1.0
+# Pin for https://github.com/jupyter/jupyter-packaging/issues/81
+setuptools>=56.0
 jupyterlab==3.0.14
 nbgitpuller==0.9.0
 jupyter-resource-usage==0.5.1

--- a/deployments/eecs/image/infra-requirements.txt
+++ b/deployments/eecs/image/infra-requirements.txt
@@ -15,7 +15,7 @@ notebook==6.2.0
 # someone opens a notebook created w/ nbformat>=5.1.0. is it possible to pin
 # below 5.1.0 while notebook patches this?
 nbformat<5.1.0
-jupyterlab==3.0.11
+jupyterlab==3.0.14
 nbgitpuller==0.9.0
 jupyter-resource-usage==0.5.1
 jupyterhub==1.3.0

--- a/deployments/julia/image/infra-requirements.txt
+++ b/deployments/julia/image/infra-requirements.txt
@@ -15,6 +15,8 @@ notebook==6.2.0
 # someone opens a notebook created w/ nbformat>=5.1.0. is it possible to pin
 # below 5.1.0 while notebook patches this?
 nbformat<5.1.0
+# Pin for https://github.com/jupyter/jupyter-packaging/issues/81
+setuptools>=56.0
 jupyterlab==3.0.14
 nbgitpuller==0.9.0
 jupyter-resource-usage==0.5.1

--- a/deployments/julia/image/infra-requirements.txt
+++ b/deployments/julia/image/infra-requirements.txt
@@ -15,7 +15,7 @@ notebook==6.2.0
 # someone opens a notebook created w/ nbformat>=5.1.0. is it possible to pin
 # below 5.1.0 while notebook patches this?
 nbformat<5.1.0
-jupyterlab==3.0.11
+jupyterlab==3.0.14
 nbgitpuller==0.9.0
 jupyter-resource-usage==0.5.1
 jupyterhub==1.3.0

--- a/deployments/r/image/infra-requirements.txt
+++ b/deployments/r/image/infra-requirements.txt
@@ -15,6 +15,8 @@ notebook==6.2.0
 # someone opens a notebook created w/ nbformat>=5.1.0. is it possible to pin
 # below 5.1.0 while notebook patches this?
 nbformat<5.1.0
+# Pin for https://github.com/jupyter/jupyter-packaging/issues/81
+setuptools>=56.0
 jupyterlab==3.0.14
 nbgitpuller==0.9.0
 jupyter-resource-usage==0.5.1

--- a/deployments/r/image/infra-requirements.txt
+++ b/deployments/r/image/infra-requirements.txt
@@ -15,7 +15,7 @@ notebook==6.2.0
 # someone opens a notebook created w/ nbformat>=5.1.0. is it possible to pin
 # below 5.1.0 while notebook patches this?
 nbformat<5.1.0
-jupyterlab==3.0.11
+jupyterlab==3.0.14
 nbgitpuller==0.9.0
 jupyter-resource-usage==0.5.1
 jupyterhub==1.3.0

--- a/deployments/stat159/image/infra-requirements.txt
+++ b/deployments/stat159/image/infra-requirements.txt
@@ -15,6 +15,8 @@ notebook==6.2.0
 # someone opens a notebook created w/ nbformat>=5.1.0. is it possible to pin
 # below 5.1.0 while notebook patches this?
 nbformat<5.1.0
+# Pin for https://github.com/jupyter/jupyter-packaging/issues/81
+setuptools>=56.0
 jupyterlab==3.0.14
 nbgitpuller==0.9.0
 jupyter-resource-usage==0.5.1

--- a/deployments/stat159/image/infra-requirements.txt
+++ b/deployments/stat159/image/infra-requirements.txt
@@ -15,7 +15,7 @@ notebook==6.2.0
 # someone opens a notebook created w/ nbformat>=5.1.0. is it possible to pin
 # below 5.1.0 while notebook patches this?
 nbformat<5.1.0
-jupyterlab==3.0.11
+jupyterlab==3.0.14
 nbgitpuller==0.9.0
 jupyter-resource-usage==0.5.1
 jupyterhub==1.3.0

--- a/deployments/template/{{cookiecutter.hub_name}}/image/infra-requirements.txt
+++ b/deployments/template/{{cookiecutter.hub_name}}/image/infra-requirements.txt
@@ -15,6 +15,8 @@ notebook==6.2.0
 # someone opens a notebook created w/ nbformat>=5.1.0. is it possible to pin
 # below 5.1.0 while notebook patches this?
 nbformat<5.1.0
+# Pin for https://github.com/jupyter/jupyter-packaging/issues/81
+setuptools>=56.0
 jupyterlab==3.0.14
 nbgitpuller==0.9.0
 jupyter-resource-usage==0.5.1

--- a/deployments/template/{{cookiecutter.hub_name}}/image/infra-requirements.txt
+++ b/deployments/template/{{cookiecutter.hub_name}}/image/infra-requirements.txt
@@ -15,7 +15,7 @@ notebook==6.2.0
 # someone opens a notebook created w/ nbformat>=5.1.0. is it possible to pin
 # below 5.1.0 while notebook patches this?
 nbformat<5.1.0
-jupyterlab==3.0.11
+jupyterlab==3.0.14
 nbgitpuller==0.9.0
 jupyter-resource-usage==0.5.1
 jupyterhub==1.3.0

--- a/scripts/infra-packages/requirements.txt
+++ b/scripts/infra-packages/requirements.txt
@@ -15,6 +15,8 @@ notebook==6.2.0
 # someone opens a notebook created w/ nbformat>=5.1.0. is it possible to pin
 # below 5.1.0 while notebook patches this?
 nbformat<5.1.0
+# Pin for https://github.com/jupyter/jupyter-packaging/issues/81
+setuptools>=56.0
 jupyterlab==3.0.14
 nbgitpuller==0.9.0
 jupyter-resource-usage==0.5.1

--- a/scripts/infra-packages/requirements.txt
+++ b/scripts/infra-packages/requirements.txt
@@ -15,7 +15,7 @@ notebook==6.2.0
 # someone opens a notebook created w/ nbformat>=5.1.0. is it possible to pin
 # below 5.1.0 while notebook patches this?
 nbformat<5.1.0
-jupyterlab==3.0.11
+jupyterlab==3.0.14
 nbgitpuller==0.9.0
 jupyter-resource-usage==0.5.1
 jupyterhub==1.3.0


### PR DESCRIPTION
Earlier, interactive use of R somehow wasn't loading
appropriate instructions on setting CRAN from Rprofile.site,
resulting (partially) in errors like this:

https://github.com/berkeley-dsep-infra/datahub/issues/2255#issuecomment-806268236

My informed guess is that the `local{}` was scoping the effects,
so it worked during build but not during interactive use.
Removing that seems to make it work for both.

Inspired by https://github.com/toolforge/paws/pull/62