### PR TITLE
Move eecs hub to delta pool

### DIFF
--- a/deployments/eecs/config/common.yaml
+++ b/deployments/eecs/config/common.yaml
@@ -58,7 +58,7 @@ jupyterhub:
       DISPLAY: ":1.0"
     defaultUrl: "/lab"
     nodeSelector:
-      hub.jupyter.org/pool-name: gamma-pool
+      hub.jupyter.org/pool-name: delta-pool
     storage:
       type: static
       static:


### PR DESCRIPTION
EECS hub students are using a *lot* of CPU, causing
issues for other hubs on gamma hub (R, bio, etc).

I've created a new pool specifically for eecs hub,
with different machine sizes - 16 CPUs + 32GB of RAM.
The overprovisioning should help deal with their workloads
well, without crushing other hubs on gamma pool. Here is
the command used:
```
gcloud container node-pools create  \                                                                                                                130 ↵
        --machine-type n1-custom-16-32768 \
        --num-nodes 2 \
        --enable-autoscaling \
        --min-nodes 1 --max-nodes 20 \
        --node-labels hub.jupyter.org/pool-name=delta-pool \
        --node-taints hub.jupyter.org_dedicated=user:NoSchedule \
        --region=us-central1 \
        --image-type=cos \
        --disk-size=200 --disk-type=pd-balanced \
        --no-enable-autoupgrade \
        --tags=hub-cluster \
        --cluster=fall-2019 \
        user-pool-delta-2021-04-26
```