### PR TITLE
Add node placeholders

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -234,6 +234,49 @@ jobs:
           command: |
             hubploy deploy eecs hub ${CIRCLE_BRANCH}
 
+  deploy-node-placeholder:
+    docker:
+      - image: buildpack-deps:bionic-scm
+    working_directory: ~/repo
+    steps:
+      - checkout
+
+      - run:
+          name: install google-cloud-sdk
+          command: |
+            curl -sSL https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-265.0.0-linux-x86_64.tar.gz | tar -xzf -
+            # Be careful with quote ordering here. ${PATH} must not be expanded
+            # Don't use ~ here - bash can interpret PATHs containing ~, but most other things can't.
+            # Always use full PATHs in PATH!
+            echo 'export PATH="${HOME}/repo/google-cloud-sdk/bin:${PATH}"' >> ${BASH_ENV}
+
+      - run:
+          name: Setup helm3
+          command: |
+            curl -L https://get.helm.sh/helm-v3.0.2-linux-amd64.tar.gz | \
+              tar -xzf -
+            mv linux-amd64/helm /usr/local/bin
+            helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+
+      - run:
+          name: Activate credentials for datahub cluster (fall-2019)
+          command: |
+            sops -d -i deployments/datahub/secrets/gke-key.json
+            gcloud auth \
+              activate-service-account \
+              --key-file deployments/datahub/secrets/gke-key.json
+
+            gcloud container clusters \
+              --region=us-central1 --project=ucb-datahub-2018 \
+              get-credentials fall-2019
+
+      - run:
+          name: Deploy node placeholder chart
+          command: |
+            helm upgrade --create-namespace \
+              --install --wait \
+              --namespace=placeholder node-placeholder node-placeholder
+
   deploy-support:
     docker:
       - image: buildpack-deps:bionic-scm
@@ -429,6 +472,15 @@ workflows:
             branches:
               only:
                 - prod
+  deploy-node-placeholder:
+    jobs:
+      - deploy-node-placeholder:
+          filters:
+            branches:
+              # We don't have staging / prod for our node placeholder pods
+              # So we deploy only when deploying staging
+              only: staging
+
   deploy-support:
     jobs:
       - deploy-support:

--- a/deployments/eecs/config/prod.yaml
+++ b/deployments/eecs/config/prod.yaml
@@ -17,5 +17,4 @@ jupyterhub:
         storage: 4Gi
   scheduling:
     userPlaceholder:
-      enabled: true
-      replicas: 60
+      enabled: false

--- a/node-placeholder/Chart.yaml
+++ b/node-placeholder/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: '1.0'
+description: Chart to keep n nodes available for hub users all the time
+name: node-placeholder
+version: 0.0.1

--- a/node-placeholder/priorityclass.yaml
+++ b/node-placeholder/priorityclass.yaml
@@ -1,0 +1,13 @@
+{{- if .Valuess.enabled }}
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: {{.Release.Name}}-node-placeholder-priority
+  labels:
+    component: node-placeholder
+    app: node-placeholder
+    release: {{ .Release.Name }}
+value: -10
+globalDefault: false
+description: "With a priority higher or eqaul to a cluster autoscalers priority cutoff, a pod can trigger a cluster scale up. At the same time, placeholder pods priority should be lower than other pods to make them evictable."
+{{- end }}

--- a/node-placeholder/templates/pdb.yaml
+++ b/node-placeholder/templates/pdb.yaml
@@ -1,0 +1,21 @@
+{{- /*
+The cluster autoscaler should be allowed to evict and reschedule these pods if
+it would help in order to scale down a node.
+*/}}
+{{- if .Values.enabled -}}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: node-placeholder
+  labels:
+    component: node-placeholder
+    app: node-placeholder
+    release: {{ .Release.Name }}
+spec:
+  minAvailable: 0
+  selector:
+    matchLabels:
+      component: node-placeholder
+      app: node-placeholder
+      release: {{ .Release.Name }}
+{{- end }}

--- a/node-placeholder/templates/priorityclass.yaml
+++ b/node-placeholder/templates/priorityclass.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.enabled }}
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: {{.Release.Name}}-node-placeholder-priority
+  labels:
+    component: node-placeholder
+    app: node-placeholder
+    release: {{ .Release.Name }}
+value: -10
+globalDefault: false
+description: "With a priority higher or eqaul to a cluster autoscalers priority cutoff, a pod can trigger a cluster scale up. At the same time, placeholder pods priority should be lower than other pods to make them evictable."
+{{- end }}

--- a/node-placeholder/templates/statefulset.yaml
+++ b/node-placeholder/templates/statefulset.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.enabled -}}
+{{ range $key, $config := .Values.nodePools }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $key }}-node-placeholder
+spec:
+  replicas: {{ $config.nodes }}
+  selector:
+    matchLabels:
+      component: node-placeholder
+      app: node-placeholder
+      release: {{ $.Release.Name }}
+  template:
+    metadata:
+      labels:
+        component: node-placeholder
+        app: node-placeholder
+        release: {{ $.Release.Name }}
+    spec:
+      priorityClassName: {{$.Release.Name}}-node-placeholder-priority
+      terminationGracePeriodSeconds: 0
+      automountServiceAccountToken: false
+      tolerations:
+      - effect: NoSchedule
+        key: hub.jupyter.org_dedicated
+        operator: Equal
+        value: user
+      - effect: NoSchedule
+        key: hub.jupyter.org/dedicated
+        operator: Equal
+        value: user
+      nodeSelector: {{ $config.nodeSelector | toJson}}
+      containers:
+        - name: pause
+          image: k8s.gcr.io/pause:3.2
+          resources: {{ $config.resources | toJson}}
+
+{{- end }}
+{{- end }}

--- a/node-placeholder/values.yaml
+++ b/node-placeholder/values.yaml
@@ -1,0 +1,15 @@
+enabled: true
+nodePools:
+  delta:
+    nodeSelector:
+      hub.jupyter.org/pool-name: delta-pool
+    resources:
+      requests:
+        # Calculated by:
+        # 1. `k get node gke-fall-2019-user-pool-delta-2021-04-2a2dd2fa-4m3w -o jsonpath='{.status.allocatable.memory}'` 
+        #    (or similar delta pool node) to determine total allocatable memory for each node
+        # 2. Subtracting just enough that when a user pod with guarantee 512M (EECS pod guarantee now) is requested,
+        #    it *must* displace this pod to fit in the node. This was a little bit of trial and error, but should be
+        #    replicable once we count other daemonset pods on this node FIXME
+        memory: 28594536Ki
+    nodes: 3


### PR DESCRIPTION
We currently use 'pod placeholders'
(https://zero-to-jupyterhub.readthedocs.io/en/stable/administrator/optimization.html)
to try keep 'headroom' of X nodes over what users are currently
using - so when a new user comes in, they can get a node right
away without needing to wait for a spinup. In practice, this has
been problematic - primarily because the unit of placeholder is *pod*,
but the unit of autoscaler is *node*. A common failure mode is

1. A new user comes in, displayes a single placeholder pod. This kicks
   off the autoscaler, and a new node spins up.
2. Another user comes in - but since the new node is emptier than the
   old node, the new user is scheduled in the new node! They have to
   then wait for the image to be pulled, which can take a long time.

So users still see a long wait, even though there's an 'empty'
node.

With the node placeholder approach, we make one pod that tries
to take up *all* the resources on a node. When a user pod comes up,
it can displace this *one* pod - and free up a full node of resources!
The displayed pod will trigger a scale-up, but since not even a single
other user pod can be on the same node as our placeholder pod, the new
user pods will continue to be on the recently vacated node.

So in our case, I've added enough headroom for 3 extra delta
nodes - primarily for use by the EECS hub. This should theoretically
help with a surge of upto 150 users over the course of new node spinup
and ready - about 15 minutes or so.

Let's try it out

Ref #2322 