### PR TITLE
Don't pass --create-namespace to helm

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -283,7 +283,7 @@ jobs:
       - run:
           name: Deploy node placeholder chart
           command: |
-            helm upgrade --create-namespace \
+            helm upgrade \
               --install --wait \
               --namespace=placeholder node-placeholder node-placeholder
 


### PR DESCRIPTION
It isn't in helm 3.0, the version we use. I've
manually created it for now - we should upgrade helm.