### PR TITLE
Limit max CPU of EECS users

### DIFF
--- a/deployments/eecs/config/common.yaml
+++ b/deployments/eecs/config/common.yaml
@@ -69,5 +69,7 @@ jupyterhub:
       limit: 2G
     cpu:
       guarantee: 0.33
+      # Limit to 2 so users can't accidentally max out a node
+      limit: 2
     image:
       name: gcr.io/ucb-datahub-2018/eecs-user-image


### PR DESCRIPTION
Some have accidentally maxed out nodes, causing issues
for other users on the node. EECS is on its own set of nodes
now - so maxing out a node can still hurt other users on the node

Ref #2322 