### PR TITLE
Bump version of JupyterHub

### DIFF
--- a/deployments/biology/image/infra-requirements.txt
+++ b/deployments/biology/image/infra-requirements.txt
@@ -20,7 +20,7 @@ setuptools>=56.0
 jupyterlab==3.0.14
 nbgitpuller==0.9.0
 jupyter-resource-usage==0.5.1
-jupyterhub==1.3.0
+jupyterhub==1.4.0
 appmode==0.8.0
 ipywidgets==7.6.3
 otter-grader==2.1.0

--- a/deployments/data8x/image/infra-requirements.txt
+++ b/deployments/data8x/image/infra-requirements.txt
@@ -20,7 +20,7 @@ setuptools>=56.0
 jupyterlab==3.0.14
 nbgitpuller==0.9.0
 jupyter-resource-usage==0.5.1
-jupyterhub==1.3.0
+jupyterhub==1.4.0
 appmode==0.8.0
 ipywidgets==7.6.3
 otter-grader==2.1.0

--- a/deployments/datahub/images/default/infra-requirements.txt
+++ b/deployments/datahub/images/default/infra-requirements.txt
@@ -20,7 +20,7 @@ setuptools>=56.0
 jupyterlab==3.0.14
 nbgitpuller==0.9.0
 jupyter-resource-usage==0.5.1
-jupyterhub==1.3.0
+jupyterhub==1.4.0
 appmode==0.8.0
 ipywidgets==7.6.3
 otter-grader==2.1.0

--- a/deployments/dlab/image/infra-requirements.txt
+++ b/deployments/dlab/image/infra-requirements.txt
@@ -20,7 +20,7 @@ setuptools>=56.0
 jupyterlab==3.0.14
 nbgitpuller==0.9.0
 jupyter-resource-usage==0.5.1
-jupyterhub==1.3.0
+jupyterhub==1.4.0
 appmode==0.8.0
 ipywidgets==7.6.3
 otter-grader==2.1.0

--- a/deployments/eecs/image/infra-requirements.txt
+++ b/deployments/eecs/image/infra-requirements.txt
@@ -20,7 +20,7 @@ setuptools>=56.0
 jupyterlab==3.0.14
 nbgitpuller==0.9.0
 jupyter-resource-usage==0.5.1
-jupyterhub==1.3.0
+jupyterhub==1.4.0
 appmode==0.8.0
 ipywidgets==7.6.3
 otter-grader==2.1.0

--- a/deployments/julia/image/infra-requirements.txt
+++ b/deployments/julia/image/infra-requirements.txt
@@ -20,7 +20,7 @@ setuptools>=56.0
 jupyterlab==3.0.14
 nbgitpuller==0.9.0
 jupyter-resource-usage==0.5.1
-jupyterhub==1.3.0
+jupyterhub==1.4.0
 appmode==0.8.0
 ipywidgets==7.6.3
 otter-grader==2.1.0

--- a/deployments/r/image/infra-requirements.txt
+++ b/deployments/r/image/infra-requirements.txt
@@ -20,7 +20,7 @@ setuptools>=56.0
 jupyterlab==3.0.14
 nbgitpuller==0.9.0
 jupyter-resource-usage==0.5.1
-jupyterhub==1.3.0
+jupyterhub==1.4.0
 appmode==0.8.0
 ipywidgets==7.6.3
 otter-grader==2.1.0

--- a/deployments/stat159/image/infra-requirements.txt
+++ b/deployments/stat159/image/infra-requirements.txt
@@ -20,7 +20,7 @@ setuptools>=56.0
 jupyterlab==3.0.14
 nbgitpuller==0.9.0
 jupyter-resource-usage==0.5.1
-jupyterhub==1.3.0
+jupyterhub==1.4.0
 appmode==0.8.0
 ipywidgets==7.6.3
 otter-grader==2.1.0

--- a/deployments/template/{{cookiecutter.hub_name}}/image/infra-requirements.txt
+++ b/deployments/template/{{cookiecutter.hub_name}}/image/infra-requirements.txt
@@ -20,7 +20,7 @@ setuptools>=56.0
 jupyterlab==3.0.14
 nbgitpuller==0.9.0
 jupyter-resource-usage==0.5.1
-jupyterhub==1.3.0
+jupyterhub==1.4.0
 appmode==0.8.0
 ipywidgets==7.6.3
 otter-grader==2.1.0

--- a/images/hub/Dockerfile
+++ b/images/hub/Dockerfile
@@ -9,7 +9,7 @@ RUN apt update > /dev/null  && apt install --yes npm > /dev/null
 # Brings in https://github.com/jupyterhub/jupyterhub/pull/3407
 # and https://github.com/jupyterhub/jupyterhub/pull/3411
 # For https://github.com/berkeley-dsep-infra/datahub/issues/2284
-RUN python3 -m pip install -U git+https://github.com/jupyterhub/jupyterhub.git@2ff6d2b36c855e86dfab188dc62b31c8738b07a5
+RUN python3 -m pip install -U jupyterhub==1.4
 
 COPY canvasauthenticator /srv/canvasauthenticator
 RUN python3 -m pip install --no-cache /srv/canvasauthenticator

--- a/scripts/infra-packages/requirements.txt
+++ b/scripts/infra-packages/requirements.txt
@@ -20,7 +20,7 @@ setuptools>=56.0
 jupyterlab==3.0.14
 nbgitpuller==0.9.0
 jupyter-resource-usage==0.5.1
-jupyterhub==1.3.0
+jupyterhub==1.4.0
 appmode==0.8.0
 ipywidgets==7.6.3
 otter-grader==2.1.0


### PR DESCRIPTION
We were using a dev version on the hubs and
1.3 on the user pods. Now that 1.4 is released, we can use
the same version in both places!