### PR TITLE
Reduce EECS CPU usage guarantee

### DIFF
--- a/deployments/eecs/config/common.yaml
+++ b/deployments/eecs/config/common.yaml
@@ -58,7 +58,7 @@ jupyterhub:
       DISPLAY: ":1.0"
     defaultUrl: "/lab"
     nodeSelector:
-      hub.jupyter.org/pool-name: delta-pool
+      hub.jupyter.org/pool-name: gamma-pool
     storage:
       type: static
       static:
@@ -71,7 +71,7 @@ jupyterhub:
       # Give eecs users 1 full CPU
       # Any overprovisioning seems to peg node CPUs pretty quickly, causing issues
       # with even execution for other users
-      guarantee: 1
+      guarantee: 0.33
       limit: 1
     image:
       name: gcr.io/ucb-datahub-2018/eecs-user-image

--- a/node-placeholder/values.yaml
+++ b/node-placeholder/values.yaml
@@ -35,10 +35,3 @@ nodePools:
       requests:
         memory: 46786Mi
     nodes: 2
-  delta:
-    nodeSelector:
-      hub.jupyter.org/pool-name: delta-pool
-    resources:
-      requests:
-        memory: 28594536Ki
-    nodes: 2


### PR DESCRIPTION
- The lab that used a lot of CPU is over. Some users might still
  need to do it - so the 1CPU limit prevents them from overwhelming
  other users. The 0.33 CPU guarantee will also ensure they are
  spread wide, and don't impact users of *other* hubs as much
- Delta node pool had more CPU per GB of RAM than our other pools.
  It isn't needed anymore.