### PR TITLE
Decrease headroom for alpha cluster

### DIFF
--- a/node-placeholder/values.yaml
+++ b/node-placeholder/values.yaml
@@ -20,7 +20,7 @@ nodePools:
     resources:
       requests:
         memory: 46786Mi
-    nodes: 3
+    nodes: 2
   beta:
     nodeSelector:
       hub.jupyter.org/pool-name: beta-pool


### PR DESCRIPTION
In the worst case scenario, this lets us handle either a
70 or 140 student surge before having to use new nodes
without images. Let's watch and see - this has been
enough headroom for a week.