### PR TITLE
update stat image to stat-user-image:d4a7d28f55ca

### DIFF
--- a/deployments/stat/config/common.yaml
+++ b/deployments/stat/config/common.yaml
@@ -52,8 +52,8 @@ jupyterhub:
 
   singleuser:
     image:
-      name: us-central1-docker.pkg.dev/ucb-datahub-2018/user-images/stat20-user-image
-      tag: 668b865bb4bc
+      name: us-central1-docker.pkg.dev/ucb-datahub-2018/user-images/stat-user-image
+      tag: d4a7d28f55ca
     extraFiles:
       remove-exporters:
         mountPath: /etc/jupyter/jupyter_notebook_config.py


### PR DESCRIPTION
Switches the stat hub's singleuser image from the old stat20-user-image to the newly rebased stat-user-image, which now builds FROM base-r-image instead of rocker/geospatial.

- Old: `us-central1-docker.pkg.dev/ucb-datahub-2018/user-images/stat20-user-image:668b865bb4bc`
- New: `us-central1-docker.pkg.dev/ucb-datahub-2018/user-images/stat-user-image:d4a7d28f55ca`

Built and pushed by berkeley-dsep-infra/stat-user-image#main (commit d4a7d28).