### PR TITLE
nature: use rocker/ml-spatial directly instead of nature-user-image

### DIFF
--- a/deployments/nature/config/common.yaml
+++ b/deployments/nature/config/common.yaml
@@ -63,7 +63,7 @@ jupyterhub:
           c.QtPNGExporter.enabled = False
           c.WebPDFExporter.embed_images = True
       jupyter-lab-overrides:
-        mountPath: /srv/conda/envs/notebook/share/jupyter/lab/settings/overrides.json
+        mountPath: /opt/venv/share/jupyter/lab/settings/overrides.json
         data:
           "@jupyterlab/notebook-extension:tracker":
             scrollPastEnd: false
@@ -73,7 +73,6 @@ jupyterhub:
       GH_SCOPED_CREDS_CLIENT_ID: Iv23liGBW8jtMBP0inyw
       GH_SCOPED_CREDS_APP_URL: https://github.com/apps/uc-berkeley-nature-hub-git-access
       JUPYTERHUB_SINGLEUSER_APP: "jupyter_server.serverapp.ServerApp"
-      JUPYTER_PATH: "/srv/conda/envs/shared-1546503/share/jupyter"
     nodeSelector:
       hub.jupyter.org/pool-name: nature-pool
     storage:
@@ -91,7 +90,7 @@ jupyterhub:
         default: true
         slug: "default-profile"   
         kubespawner_override: {
-          image: "us-central1-docker.pkg.dev/ucb-datahub-2018/user-images/nature-user-image:e8a8cfb91ec3"
+          image: "ghcr.io/rocker-org/ml-spatial@sha256:4fa3a2a78fb77adbeb4f323c51e63c68552da6b8aba94333e1989f7d2a0cc784"
         }
         profile_options:
           interface:
@@ -124,7 +123,7 @@ jupyterhub:
               nature:
                 display_name: "Nature Image"
                 kubespawner_override:
-                  image: us-central1-docker.pkg.dev/ucb-datahub-2018/user-images/nature-user-image:e8a8cfb91ec3
+                  image: ghcr.io/rocker-org/ml-spatial@sha256:4fa3a2a78fb77adbeb4f323c51e63c68552da6b8aba94333e1989f7d2a0cc784
             unlisted_choice:
               enabled: true
               display_name: "Publicly Accessible Custom Image (e.g. quay.io/my-project/my-image:tag)"
@@ -188,7 +187,7 @@ jupyterhub:
               nature:
                 display_name: "Nature Image"
                 kubespawner_override:
-                  image: us-central1-docker.pkg.dev/ucb-datahub-2018/user-images/nature-user-image:e8a8cfb91ec3
+                  image: ghcr.io/rocker-org/ml-spatial@sha256:4fa3a2a78fb77adbeb4f323c51e63c68552da6b8aba94333e1989f7d2a0cc784
             unlisted_choice:
               enabled: true
               display_name: "Publicly Accessible Custom Image (e.g. quay.io/my-project/my-image:tag)"
@@ -229,7 +228,7 @@ jupyterhub:
               nature:
                 display_name: "Nature Image"
                 kubespawner_override:
-                  image: us-central1-docker.pkg.dev/ucb-datahub-2018/user-images/nature-user-image:e8a8cfb91ec3
+                  image: ghcr.io/rocker-org/ml-spatial@sha256:4fa3a2a78fb77adbeb4f323c51e63c68552da6b8aba94333e1989f7d2a0cc784
             unlisted_choice:
               enabled: true
               display_name: "Publicly Accessible Custom Image (e.g. quay.io/my-project/my-image:tag)"
@@ -293,7 +292,7 @@ jupyterhub:
               nature:
                 display_name: "Nature Image"
                 kubespawner_override:
-                  image: us-central1-docker.pkg.dev/ucb-datahub-2018/user-images/nature-user-image:e8a8cfb91ec3
+                  image: ghcr.io/rocker-org/ml-spatial@sha256:4fa3a2a78fb77adbeb4f323c51e63c68552da6b8aba94333e1989f7d2a0cc784
             unlisted_choice:
               enabled: true
               display_name: "Publicly Accessible Custom Image (e.g. quay.io/my-project/my-image:tag)"
@@ -332,7 +331,7 @@ jupyterhub:
               nature:
                 display_name: "Nature Image"
                 kubespawner_override:
-                  image: us-central1-docker.pkg.dev/ucb-datahub-2018/user-images/nature-user-image:e8a8cfb91ec3
+                  image: ghcr.io/rocker-org/ml-spatial@sha256:4fa3a2a78fb77adbeb4f323c51e63c68552da6b8aba94333e1989f7d2a0cc784
             unlisted_choice:
               enabled: true
               display_name: "Publicly Accessible Custom Image (e.g. quay.io/my-project/my-image:tag)"
@@ -379,9 +378,3 @@ jupyterhub:
                 kubespawner_override:
                   default_url: "/lab"
   
-  custom:
-    conda_shared:
-      - bcourse_group: "course::1546503"
-        staff_overrides:
-          mem_limit: 8G
-          mem_guarantee: 8G


### PR DESCRIPTION
Points the `nature` hub at [`rocker/ml-spatial`](https://github.com/rocker-org/ml) directly and retires the repo2docker build in `berkeley-dsep-infra/nature-user-image`.

I maintain rocker/ml, so this consolidates two images I was keeping in sync by hand into one. Flagging for review rather than merging quietly, since `nature` would be the first deployment pulling from outside the project's own registry.

## Why the course image is no longer needed

`rocker/ml-spatial` already satisfies the singleuser contract. I verified each of these in the running container rather than reading it off the Dockerfile:

| | |
|---|---|
| `id` | `uid=1000(jovyan) gid=1000 … 100(users)`, `HOME=/home/jovyan` |
| `jupyterhub-singleuser` | `/opt/venv/bin/jupyterhub-singleuser`, jupyterhub 5.5.1 |
| `/vscode/` | HTTP 200 — this is the `default_url` for every profile |
| `/rstudio/` | HTTP 302 → login |
| code-server extensions | `/opt/share/code-server`, outside `$HOME`, so they survive the PVC mount |

`jupyter-vscode-proxy` reads `CODE_EXTENSIONSDIR` directly, which the image sets — so the VSCode default interface works with no glue.

The image also carries the R and Python spatial stacks the courses use (`sf`, `stars`, `terra`, `gdalcubes`, `rstac`, `mapgl`, `duckdbfs`; `rasterio`/`fiona`/`pyogrio` built against the system GDAL).

Everything else `nature-user-image` was installing turned out to be unused: no R Jupyter kernel is needed (students work in RStudio and VSCode), and no nbgitpuller (students submit work as commits to GitHub).

## GHCR rather than Docker Hub

Same image — the amd64 layer digest is identical in both registries — but GHCR has no anonymous pull rate limit, which matters when the node pool scales up and pulls ~3.3 GB.

## Pinned by digest

Deliberate. `rocker/ml-spatial:latest` is rebuilt weekly and tracks upstream on purpose; a course image must not move under students mid-semester. The digest gets bumped between terms, or whenever we want a change, rather than drifting.

## The other three hunks

- **`jupyter-lab-overrides`** moves from `/srv/conda/envs/notebook/share/jupyter/...` to `/opt/venv/share/jupyter/...`. Left as-is it would mount into a path that doesn't exist and `scrollPastEnd: false` would stop applying with no error.
- **`JUPYTER_PATH`** and **`custom.conda_shared`** are dropped. Both exist only to serve a shared conda env, which a venv-based image can't use. `course::1546503` appears nowhere else in the repo.

## One thing worth a second opinion

Removing `conda_shared` also removes the staff memory bump it carried (8G limit/guarantee for teachers and TAs in `course::1546503`, via `mem_cmp` in `hub/values.yaml`). Since that group isn't in the `profileList`, those users fall back to the default profile's 4G. Happy to add an explicit `mem_limit`/`mem_guarantee` to the instructor profiles in this PR if that bump is still wanted — just say which group.

## Testing

Built and smoke-tested locally against the pinned digest. Not yet run on staging — glad to have this deployed there first.
