### PR TITLE
nature: bump rocker/ml-spatial digest

### DIFF
--- a/deployments/nature/config/common.yaml
+++ b/deployments/nature/config/common.yaml
@@ -90,7 +90,7 @@ jupyterhub:
         default: true
         slug: "default-profile"   
         kubespawner_override: {
-          image: "ghcr.io/rocker-org/ml-spatial@sha256:4fa3a2a78fb77adbeb4f323c51e63c68552da6b8aba94333e1989f7d2a0cc784"
+          image: "ghcr.io/rocker-org/ml-spatial@sha256:fbb7d0f84384665716892d09b4e16595a7be76e62f66e898a42a87535bfa3b79"
         }
         profile_options:
           interface:
@@ -123,7 +123,7 @@ jupyterhub:
               nature:
                 display_name: "Nature Image"
                 kubespawner_override:
-                  image: ghcr.io/rocker-org/ml-spatial@sha256:4fa3a2a78fb77adbeb4f323c51e63c68552da6b8aba94333e1989f7d2a0cc784
+                  image: ghcr.io/rocker-org/ml-spatial@sha256:fbb7d0f84384665716892d09b4e16595a7be76e62f66e898a42a87535bfa3b79
             unlisted_choice:
               enabled: true
               display_name: "Publicly Accessible Custom Image (e.g. quay.io/my-project/my-image:tag)"
@@ -187,7 +187,7 @@ jupyterhub:
               nature:
                 display_name: "Nature Image"
                 kubespawner_override:
-                  image: ghcr.io/rocker-org/ml-spatial@sha256:4fa3a2a78fb77adbeb4f323c51e63c68552da6b8aba94333e1989f7d2a0cc784
+                  image: ghcr.io/rocker-org/ml-spatial@sha256:fbb7d0f84384665716892d09b4e16595a7be76e62f66e898a42a87535bfa3b79
             unlisted_choice:
               enabled: true
               display_name: "Publicly Accessible Custom Image (e.g. quay.io/my-project/my-image:tag)"
@@ -228,7 +228,7 @@ jupyterhub:
               nature:
                 display_name: "Nature Image"
                 kubespawner_override:
-                  image: ghcr.io/rocker-org/ml-spatial@sha256:4fa3a2a78fb77adbeb4f323c51e63c68552da6b8aba94333e1989f7d2a0cc784
+                  image: ghcr.io/rocker-org/ml-spatial@sha256:fbb7d0f84384665716892d09b4e16595a7be76e62f66e898a42a87535bfa3b79
             unlisted_choice:
               enabled: true
               display_name: "Publicly Accessible Custom Image (e.g. quay.io/my-project/my-image:tag)"
@@ -292,7 +292,7 @@ jupyterhub:
               nature:
                 display_name: "Nature Image"
                 kubespawner_override:
-                  image: ghcr.io/rocker-org/ml-spatial@sha256:4fa3a2a78fb77adbeb4f323c51e63c68552da6b8aba94333e1989f7d2a0cc784
+                  image: ghcr.io/rocker-org/ml-spatial@sha256:fbb7d0f84384665716892d09b4e16595a7be76e62f66e898a42a87535bfa3b79
             unlisted_choice:
               enabled: true
               display_name: "Publicly Accessible Custom Image (e.g. quay.io/my-project/my-image:tag)"
@@ -331,7 +331,7 @@ jupyterhub:
               nature:
                 display_name: "Nature Image"
                 kubespawner_override:
-                  image: ghcr.io/rocker-org/ml-spatial@sha256:4fa3a2a78fb77adbeb4f323c51e63c68552da6b8aba94333e1989f7d2a0cc784
+                  image: ghcr.io/rocker-org/ml-spatial@sha256:fbb7d0f84384665716892d09b4e16595a7be76e62f66e898a42a87535bfa3b79
             unlisted_choice:
               enabled: true
               display_name: "Publicly Accessible Custom Image (e.g. quay.io/my-project/my-image:tag)"


### PR DESCRIPTION
Bumps the `nature` image pin from `sha256:4fa3a2a7…` to `sha256:fbb7d0f8…`, the first digest move since #8422 set this hub up on `rocker/ml-spatial`.

## What this picks up

Two fixes in [rocker-org/ml](https://github.com/rocker-org/ml), which I maintain:

- **[#59](https://github.com/rocker-org/ml/pull/59) — Kilo Code config now persists.** Kilo (the AI assistant extension in VS Code) kept its config in `$XDG_CONFIG_HOME`, which this image deliberately points outside `$HOME` so pre-installed config isn't shadowed by the PVC mount. The side effect was that anything Kilo *wrote* there was discarded: a student who configured a custom model had to redo it on every server restart. Its config directory is now a symlink into `~/.config/kilo`, on the persistent home volume. This is the fix that prompted the bump.
- **[#60](https://github.com/rocker-org/ml/pull/60) — `python3-dev` in the spatial images.** The Python spatial stack is compiled from source against the system GDAL, and the headers it needs were arriving only as an accidental transitive dependency of an R package. When that went away every spatial build failed at `shapely` with `fatal error: Python.h`. No user-visible change, but without it there is no new image to pin.

Beyond those, the image is rebuilt against current upstream, so this also carries a few days of ordinary package churn.

## Verified in the pinned image

Run against `ghcr.io/rocker-org/ml-spatial@sha256:fbb7d0f8…` itself, not a local build:

| | |
|---|---|
| Kilo config location | `/opt/share/xdg-config/kilo` → `/home/jovyan/.config/kilo` (persistent) |
| Kilo providers seeded | `['nrp', 'copilot']` |
| Python bindings | rasterio/fiona/pyogrio on system GDAL 3.12.2 |
| Arrow/Parquet drivers | both load in `ogrinfo --formats` |
| R spatial | sf 1.1.2, terra 1.9.46 |

The pin is the multi-arch index digest, matching the form #8422 used.
